### PR TITLE
[MediaFoundation]Remaping interfaces for a proper IMFTransform usage

### DIFF
--- a/Source/SharpDX.MediaFoundation/Mapping-core.xml
+++ b/Source/SharpDX.MediaFoundation/Mapping-core.xml
@@ -97,6 +97,7 @@
     <create visibility="public static" class="AudioRendererAttributeKeys" />
     <create visibility="public static" class="ByteStreamAttributeKeys" />
     <create visibility="public static" class="CaptureDeviceAttributeKeys" />
+    <create visibility="public static" class="TransformCategoryGuids" />
 
     <ifdef name="DIRECTX11_1">
       <create visibility="public static" class="CaptureEngineAttributeKeys" />
@@ -106,7 +107,7 @@
       <create visibility="public static" class="Mpeg4MediaSinkAttributeKeys" />
       <create visibility="public static" class="NaluAttributeKeys" />
       <create visibility="public static" class="ProtectionAttributeKeys" />
-
+      
       <const from-guid="MF_CAPTURE_ENGINE_D3D_MANAGER" class="SharpDX.MediaFoundation.CaptureEngineAttributeKeys" type="MediaAttributeKey&lt;SharpDX.ComObject&gt;" name="D3DManager">new MediaAttributeKey&lt;SharpDX.ComObject&gt;("$1")</const>
       <const from-guid="MF_CAPTURE_ENGINE_DECODER_MFT_FIELDOFUSE_UNLOCK_Attribute" class="SharpDX.MediaFoundation.CaptureEngineAttributeKeys" type="MediaAttributeKey&lt;SharpDX.ComObject&gt;" name="DecoderTransformFieldOfUseUnlockAttribute">new MediaAttributeKey&lt;SharpDX.ComObject&gt;("$1")</const>
       <const from-guid="MF_CAPTURE_ENGINE_DISABLE_DXVA" class="SharpDX.MediaFoundation.CaptureEngineAttributeKeys" type="MediaAttributeKey&lt;bool&gt;" name="DisableDXVA">new MediaAttributeKey&lt;bool&gt;("$1")</const>
@@ -564,6 +565,13 @@
 
     <const from-guid="CLSID_MFMediaEngineClassFactory" visibility="internal" class="SharpDX.MediaFoundation.MediaEngineClassFactory" type="System.Guid" name="CLSID_MFMediaEngineClassFactory">new System.Guid("$1")</const>
 
+    <const from-guid="MFSampleExtension_DescrambleData" class="SharpDX.MediaFoundation.SampleAttributeKeys" type="MediaAttributeKey&lt;long&gt;" name="DescrambleData">new MediaAttributeKey&lt;long&gt;("$1")</const>
+    <const from-guid="MFSampleExtension_SampleKeyID" class="SharpDX.MediaFoundation.SampleAttributeKeys" type="MediaAttributeKey&lt;int&gt;" name="SampleKeyID">new MediaAttributeKey&lt;int&gt;("$1")</const>
+    <const from-guid="MFSampleExtension_GenKeyFunc" class="SharpDX.MediaFoundation.SampleAttributeKeys" type="MediaAttributeKey&lt;long&gt;" name="GenKeyFunc">new MediaAttributeKey&lt;long&gt;("$1")</const>
+    <const from-guid="MFSampleExtension_GenKeyCtx" class="SharpDX.MediaFoundation.SampleAttributeKeys" type="MediaAttributeKey&lt;long&gt;" name="GenKeyCtx">new MediaAttributeKey&lt;long&gt;("$1")</const>
+    <const from-guid="MFSampleExtension_PacketCrossOffsets" class="SharpDX.MediaFoundation.SampleAttributeKeys" type="MediaAttributeKey&lt;byte[]&gt;" name="PacketCrossOffsets">new MediaAttributeKey&lt;byte[]&gt;("$1")</const>
+    <const from-guid="MFT_CATEGORY_(.*)" class="SharpDX.MediaFoundation.TransformCategoryGuids" type="System.Guid" name="$1">new Guid("$1")</const>
+
     <context-clear />
   </extension>
 
@@ -620,6 +628,11 @@
     
     <map enum="ASF_SELECTION_STATUS" name="AsfSelectionStatus"/>
     <map enum-item="ASF_STATUS_(.*)" name-tmp="$1"/>
+
+    <map enum="_MFT_ENUM_FLAG" name="TransformEnumFlag"/>
+    <map enum-item="MFT_ENUM_FLAG_(.*)" name-tmp="$1"/>
+    <map enum="_MFT_PROCESS_OUTPUT_FLAGS" name="TransformProcessOutputFlags"/>
+    <map enum="_MFT_PROCESS_OUTPUT_STATUS" name="TransformProcessOutputStatus"/>
 
     <!--
     // *****************************************************************
@@ -895,8 +908,26 @@
     <map function="CreateNamedPropertyStore" dll='"mf.dll"'/>
     <map function="CopyPropertyStore" dll='"mf.dll"'/>
     <map function="ConvertPropVariant" dll='"mf.dll"'/>
-    <map function="AppendPropVariant" dll='"mf.dll"'/>    
+    <map function="AppendPropVariant" dll='"mf.dll"'/>
 
+
+    <map function="MFTEnumEx" visibility="internal"/>
+    <map param="MFTEnumEx::pppMFTActivate" type="void" attribute="out"/>
+    
+    <map param="IMFASFMultiplexer::GetNextPacket::pdwStatusFlags" attribute="out"/>
+    <map param="IMFASFMultiplexer::GetNextPacket::pdwStatusFlags" type="ASF_STATUSFLAGS"/>
+
+    <map method="IMFTransform::GetStreamIDs" visibility="internal"/>
+    <map method="IMFTransform::GetStreamIDs" check ="false"/>
+
+    <map method="IMFTransform::GetOutputAvailableType" visibility="internal"/>
+    <map method="IMFTransform::GetOutputAvailableType" check ="false"/>
+
+    <map method="IMFTransform::ProcessOutput" visibility="internal"/>
+    <map method="IMFTransform::ProcessOutput" check ="false"/>
+    <map param="IMFTransform::ProcessOutput::dwFlags" type="_MFT_PROCESS_OUTPUT_FLAGS"/>
+    <map param="IMFTransform::ProcessOutput::pdwStatus" type="_MFT_PROCESS_OUTPUT_STATUS" attribute="out"/>
+    
     <context-clear />
   </mapping>
 </config>

--- a/Source/SharpDX.MediaFoundation/MediaFactory.cs
+++ b/Source/SharpDX.MediaFoundation/MediaFactory.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace SharpDX.MediaFoundation
+{
+    public static partial class MediaFactory
+    {
+        /// <summary>
+        /// Gets a list of Microsoft Media Foundation transforms (MFTs) that match specified search criteria. This function extends the <strong><see cref="SharpDX.MediaFoundation.MediaFactory.TEnum"/></strong> function.
+        /// </summary>
+        /// <param name="guidCategory">A GUID that specifies the category of MFTs to enumerate. For a list of MFT categories, see <strong><see cref="SharpDX.MediaFoundation.TransformCategoryGuids"/></strong>.</param>
+        /// <param name="enumFlags">The bitwise OR of zero or more flags from the <strong><see cref="SharpDX.MediaFoundation.TransformEnumFlag"/></strong> enumeration.</param>
+        /// <param name="inputTypeRef">A pointer to an <strong><see cref="SharpDX.MediaFoundation.TRegisterTypeInformation"/></strong> structure that specifies an input media type to match.<para>This parameter can be NULL. If NULL, all input types are matched.</para></param>
+        /// <param name="outputTypeRef">A pointer to an <strong><see cref="SharpDX.MediaFoundation.TRegisterTypeInformation"/></strong> structure that specifies an output media type to match.<para>This parameter can be NULL. If NULL, all output types are matched.</para></param>
+        /// <returns>Returnss an array of <strong><see cref="SharpDX.MediaFoundation.Activate"/></strong> objects. Each object represents an activation object for an MFT that matches the search criteria. The function allocates the memory for the array. The caller must release the pointers and call the Dispose for each element in the array.</returns>
+        public static Activate[] TEnumEx(Guid guidCategory, TransformEnumFlag enumFlags, TRegisterTypeInformation? inputTypeRef, TRegisterTypeInformation? outputTypeRef)
+        {
+            IntPtr pActivatesArr;
+            int pNumActivates;
+            TEnumEx(guidCategory, (int)enumFlags, inputTypeRef, outputTypeRef, out pActivatesArr, out pNumActivates);
+
+            var activates = new Activate[pNumActivates];
+            unsafe
+            {
+                IntPtr* ptr = (IntPtr*)(pActivatesArr);
+                for (int i = 0; i < pNumActivates; i++)
+                {
+                    activates[i] = new Activate(*ptr);
+                    ptr++;
+                }
+            }
+            Marshal.FreeCoTaskMem(pActivatesArr);
+
+            return activates;
+        }
+    }
+}

--- a/Source/SharpDX.MediaFoundation/SharpDX.MediaFoundation.csproj
+++ b/Source/SharpDX.MediaFoundation/SharpDX.MediaFoundation.csproj
@@ -47,6 +47,7 @@
     <Compile Include="MediaAttributes.cs" />
     <Compile Include="MediaEngine.cs" />
     <Compile Include="MediaEngineAttributes.cs" />
+    <Compile Include="MediaFactory.cs" />
     <Compile Include="MediaManager.cs" />
     <Compile Include="MediaType.cs" />
     <Compile Include="NamespaceDoc.cs" />
@@ -54,6 +55,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResourceCharacteristics.cs" />
     <Compile Include="SourceReader.cs" />
+    <Compile Include="Transform.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Documentation\CodeComments.xml" />

--- a/Source/SharpDX.MediaFoundation/Transform.cs
+++ b/Source/SharpDX.MediaFoundation/Transform.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SharpDX.MediaFoundation
+{
+    public partial class Transform
+    {
+        public const uint E_NotImplemented = 0x80004001;
+        public const uint MF_E_NO_MORE_TYPES = 0xC00D36B9;
+        public const uint MF_E_TRANSFORM_NEED_MORE_INPUT = 0xC00D6D72;
+
+        /// <summary>
+        /// Gets the stream identifiers for the input and output streams on this Media Foundation transform (MFT).
+        /// </summary>
+        /// <param name="dwInputIDsRef">An array allocated by the caller. The method fills the array with the input stream identifiers. The array size must be at least equal to the number of input streams. To get the number of input streams, call <strong><see cref="SharpDX.MediaFoundation.Transform.GetStreamCount"/></strong>.<para>If the caller passes an array that is larger than the number of input streams, the MFT must not write values into the extra array entries.</para></param>
+        /// <param name="dwOutputIDsRef">An array allocated by the caller. The method fills the array with the output stream identifiers. The array size must be at least equal to the number of output streams. To get the number of output streams, call <strong><see cref="SharpDX.MediaFoundation.Transform.GetStreamCount"/></strong>.<para>If the caller passes an array that is larger than the number of output streams, the MFT must not write values into the extra array entries.</para></param>
+        /// <param name="isImplemented">If true, Both streams IDs for input and output assumed 0.</param>
+        public void GetStreamIDs(int[] dwInputIDsRef, int[] dwOutputIDsRef, out bool isNotImplemented)
+        {
+            Result result = GetStreamIDs(dwInputIDsRef.Length, dwInputIDsRef, dwOutputIDsRef.Length, dwOutputIDsRef);
+
+            //if not implemented
+            if ((uint)result.Code == E_NotImplemented)
+            {
+                isNotImplemented = true;
+            }
+            else
+            {
+                isNotImplemented = false;
+                result.CheckError();
+            }
+        }
+
+        /// <summary>
+        /// Gets an available media type for an output stream on this Media Foundation transform (MFT).
+        /// </summary>
+        /// <param name="dwOutputStreamID">Output stream identifier. To get the list of stream identifiers, call <strong><see cref="SharpDX.MediaFoundation.Transform.GetStreamIDs"/></strong>.</param>
+        /// <param name="dwTypeIndex">Index of the media type to retrieve. Media types are indexed from zero and returned in approximate order of preference.</param>
+        /// <param name="typeOut">Receives a pointer to the <strong><see cref="SharpDX.MediaFoundation.MediaType"/></strong> interface. The caller must release the interface.</param>
+        /// <param name="objectRanOutOfMediaTypes">Returns true if no more output media types is available</param>
+        public void GetOutputAvailableType(int dwOutputStreamID, int dwTypeIndex, out MediaType typeOut, out bool objectRanOutOfMediaTypes)
+        {
+            objectRanOutOfMediaTypes = false;
+            var __result__ = GetOutputAvailableType(dwOutputStreamID, dwTypeIndex, out typeOut);
+
+            //An object ran out of media types
+            if ((uint)__result__.Code == MF_E_NO_MORE_TYPES)
+            {
+                objectRanOutOfMediaTypes = true;
+            }
+            else
+            {
+                __result__.CheckError();
+            }
+        }
+
+        /// <summary>
+        /// Generates output from the current input data.
+        /// </summary>
+        /// <param name="dwFlags">Bitwise OR of zero or more flags from the <strong><see cref="SharpDX.MediaFoundation.TransformProcessOutputFlags"/></strong> enumeration.</param>
+        /// <param name="outputSamplesRef">Pointer to an array of <strong><see cref="SharpDX.MediaFoundation.TOutputDataBuffer"/></strong> structures, allocated by the caller. The MFT uses this array to return output data to the caller.</param>
+        /// <param name="dwStatusRef">Receives a bitwise OR of zero or more flags from the <strong><see cref="SharpDX.MediaFoundation.TransformProcessOutputStatus"/></strong> enumeration.</param>
+        /// <param name="needMoreInput">Returns true if the transform cannot produce output data until it receives more input data.</param>
+        public void ProcessOutput(TransformProcessOutputFlags dwFlags, TOutputDataBuffer[] outputSamplesRef, out TransformProcessOutputStatus dwStatusRef, out bool needMoreInput)
+        {
+            needMoreInput = false;
+            var __result__ = ProcessOutput(dwFlags, outputSamplesRef.Length, outputSamplesRef[0], out dwStatusRef);
+            if ((uint)__result__.Code == MF_E_TRANSFORM_NEED_MORE_INPUT)
+            {
+                needMoreInput = true;
+            }
+            else
+                __result__.CheckError();
+        }
+
+    }
+}


### PR DESCRIPTION
Mapping missing enums, remapping some MF interfaces to allow audio
encoding and decoding using IMFTransform, tested on (any to wma) (wma to
PCM) encoding and decoding.
