### PR TITLE
[Toolkit.Input] Fixed duplicate keys on .NET 2.0 platform.

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.Input/KeyboardManager.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Input/KeyboardManager.cs
@@ -88,7 +88,11 @@ namespace SharpDX.Toolkit.Input
         /// <param name="key">The pressed key</param>
         private void HandleKeyPressed(Keys key)
         {
+            // need to remove pressed key only on .NET 2.0 platform, as others are using HashSet
+            // for storage which disallows duplicates
+#if WinFormsInterop && !NET35Plus // .NET 2.0
             pressedKeys.Remove(key);
+#endif
             pressedKeys.Add(key);
         }
 


### PR DESCRIPTION
The fix in https://github.com/sharpdx/SharpDX/commit/b936644bd1a2a6e325113716606c31eed302adb4 is correct, however I have added compiler directive around it to avoid unnecessary calls on other platforms as HashSet<T> ignores duplicate entries.
