### PR TITLE
[Tookit.Graphics]Make GraphicsAdapter.DisposeStatic public to allow a complete cleanup by user.

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.Graphics/GraphicsAdapter.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Graphics/GraphicsAdapter.cs
@@ -232,7 +232,7 @@ namespace SharpDX.Toolkit.Graphics
         /// <summary>
         /// Disposes of all objects
         /// </summary>
-        internal static void DisposeStatic()
+        public static void DisposeStatic()
         {
             ((IDisposable)staticCollector).Dispose();
         }


### PR DESCRIPTION
I'll be happy when ObjectTracker reports that zero objects alive, and those static objects related to GraphicsAdapter are not disposed automatically, so this is a short way to dispose them all in one shot.
