### PR TITLE
GraphicsDeviceManager.Dispose() was throwing an Exception on WinRT

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.Game/GraphicsDeviceManager.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Game/GraphicsDeviceManager.cs
@@ -487,13 +487,13 @@ namespace SharpDX.Toolkit
                     if (GraphicsDevice.Presenter != null)
                     {
 						
-						// Invalid for WinRT - throwing a "Value does not fall within the expected range" Exception
+                        // Invalid for WinRT - throwing a "Value does not fall within the expected range" Exception
 #if !WIN8METRO
-						// Make sure that the Presenter is reverted to window before shutting down
+                        // Make sure that the Presenter is reverted to window before shutting down
                         // otherwise the Direct3D11.Device will generate an exception on Dispose()
-						GraphicsDevice.Presenter.IsFullScreen = false;			
+                        GraphicsDevice.Presenter.IsFullScreen = false;			
 #endif
-						GraphicsDevice.Presenter.Dispose();
+                        GraphicsDevice.Presenter.Dispose();
                         GraphicsDevice.Presenter = null;
                     }
 


### PR DESCRIPTION
Trying to change out of full screen mode is throwing an exception, but is required for non-WinRT platforms. A simple preprocessor check for WinRT around the call prevents it from happening. 
