### PR TITLE
[Toolkit.Samples] Moved KeyboardManager creation from LoadContent to game constructor

### DIFF
--- a/Samples/Toolkit/Common/ModelRendering/ModelRenderingGame.cs
+++ b/Samples/Toolkit/Common/ModelRendering/ModelRenderingGame.cs
@@ -62,6 +62,8 @@ namespace ModelRendering
             graphicsDeviceManager = new GraphicsDeviceManager(this); 
             graphicsDeviceManager.DeviceCreationFlags = DeviceCreationFlags.Debug;
 
+            keyboard = new KeyboardManager(this);
+
             // Setup the relative directory to the executable directory
             // for loading contents with the ContentManager
             Content.RootDirectory = "Content";
@@ -75,7 +77,6 @@ namespace ModelRendering
             // Load the model (by default the model is loaded with a BasicEffect. Use ModelContentReaderOptions to change the behavior at loading time.
             //model = Content.Load<Model>("duck");
             //model = Content.Load<Model>("ShipMestaty");
-            keyboard = new KeyboardManager(this);
 
             models = new List<Model>();
             foreach (var modelName in new[] { "Dude", "Duck", "Car", "Happy", "Knot", "Skull", "Sphere", "Teapot" })
@@ -88,7 +89,6 @@ namespace ModelRendering
                 models.Add(model);
             }
             model = models[0];
-
 
             // Instantiate a SpriteBatch
             spriteBatch = ToDisposeContent(new SpriteBatch(GraphicsDevice));


### PR DESCRIPTION
Having KeyboardManager created in LoadContent may create two instances (if content will be recreated - on device reset, for example - I am not sure if this is applicable to Toolkit.Game).

The input managers were designed to be instantiated only once - two instances may not work correctly and will slow down the app.

I'm thinking if there can be created a mechanism of component instantiation, that will make sure it is put in the right place - but it may be over-engineering at this time. What do you think?
