### PR TITLE
[Toolkit.Compiler] fixed model compilation to create destination subdirectories

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.Compiler/Model/ModelCompiler.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Compiler/Model/ModelCompiler.cs
@@ -106,6 +106,13 @@ namespace SharpDX.Toolkit.Graphics
 
                     var modelData = result.ModelData;
 
+                    // Make sure that directory name doesn't collide with filename
+                    var directoryName = Path.GetDirectoryName(outputFile + ".tmp");
+                    if (!string.IsNullOrEmpty(directoryName) && !Directory.Exists(directoryName))
+                    {
+                        Directory.CreateDirectory(directoryName);
+                    }
+
                     // Save the model
                     modelData.Save(outputFile);
 


### PR DESCRIPTION
The code in diff was present in FontCompiler and EffectCompiler classes.
It looks like the same code in "...CompilerTask" classes does not work - this needs to be investigated further.
These classes have a lot of common code - logging, error handling, file operations, etc.
I can refactor it in this weekend, what do you think?
