### PR TITLE
[Toolkit.Compiler] Fixed texture compilation task to work with subfolders

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.CompilerTask/TextureCompilerTask.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.CompilerTask/TextureCompilerTask.cs
@@ -29,6 +29,9 @@ namespace SharpDX.Toolkit
     {
         protected override Diagnostics.Logger ProcessFileAndGetLogResults(string inputFilePath, string outputFilePath, string dependencyFilePath, TkItem item)
         {
+            // the textures can be in a subdirectory - make sure it exists before copying there:
+            CreateDirectoryIfNotExists(outputFilePath);
+
             // For the TextureCompilerTask, simply copy input to output without performing any resize/compression
             // but a future version will introduce this
             File.Copy(inputFilePath, outputFilePath, true);


### PR DESCRIPTION
Without this, ToolkitTexture compilation task may fail with the message like "Could not find part of the path <project path>\obj\bin<subfolder here><texture here>...".

The same issue was for EffectCompilerTask - probably the fix should be moved higher in the class hierarchy.
