### PR TITLE
[Toolkit.Graphics] Desktop platform over RDP, Part 1

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.Game/GamePlatform.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Game/GamePlatform.cs
@@ -210,19 +210,7 @@ namespace SharpDX.Toolkit
                     // Check if this profile is supported.
                     if (graphicsAdapter.IsProfileSupported(featureLevel))
                     {
-                        var deviceInfo = new GraphicsDeviceInformation
-                            {
-                                Adapter = graphicsAdapter,
-                                GraphicsProfile = featureLevel,
-                                PresentationParameters =
-                                    {
-                                        MultiSampleCount = MSAALevel.None,
-                                        IsFullScreen = prefferedParameters.IsFullScreen,
-                                        PresentationInterval = prefferedParameters.SynchronizeWithVerticalRetrace ? PresentInterval.One : PresentInterval.Immediate,
-                                        DeviceWindowHandle = MainWindow.NativeWindow,
-                                        RenderTargetUsage = Usage.BackBuffer | Usage.RenderTargetOutput
-                                    }
-                            };
+                        var deviceInfo = CreateGraphicsDeviceInformation(prefferedParameters, graphicsAdapter, featureLevel);
 
                         if (graphicsAdapter.CurrentDisplayMode != null)
                         {
@@ -245,6 +233,25 @@ namespace SharpDX.Toolkit
             }
 
             return graphicsDeviceInfos;
+        }
+
+        protected GraphicsDeviceInformation CreateGraphicsDeviceInformation(GameGraphicsParameters prefferedParameters,
+                                                                            GraphicsAdapter graphicsAdapter,
+                                                                            FeatureLevel featureLevel)
+        {
+            return new GraphicsDeviceInformation
+                   {
+                       Adapter = graphicsAdapter,
+                       GraphicsProfile = featureLevel,
+                       PresentationParameters =
+                       {
+                           MultiSampleCount = MSAALevel.None,
+                           IsFullScreen = prefferedParameters.IsFullScreen,
+                           PresentationInterval = prefferedParameters.SynchronizeWithVerticalRetrace ? PresentInterval.One : PresentInterval.Immediate,
+                           DeviceWindowHandle = MainWindow.NativeWindow,
+                           RenderTargetUsage = Usage.BackBuffer | Usage.RenderTargetOutput
+                       }
+                   };
         }
 
         public virtual GraphicsDevice CreateDevice(GraphicsDeviceInformation deviceInformation)

--- a/Source/Toolkit/SharpDX.Toolkit.Game/WinRT/GamePlatformWinRT.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Game/WinRT/GamePlatformWinRT.cs
@@ -60,19 +60,7 @@ namespace SharpDX.Toolkit
                     // Check if this profile is supported.
                     if (graphicsAdapter.IsProfileSupported(featureLevel))
                     {
-                        var deviceInfo = new GraphicsDeviceInformation
-                                             {
-                                                 Adapter = graphicsAdapter,
-                                                 GraphicsProfile = featureLevel,
-                                                 PresentationParameters =
-                                                     {
-                                                         MultiSampleCount = MSAALevel.None,
-                                                         IsFullScreen = prefferedParameters.IsFullScreen,
-                                                         PresentationInterval = prefferedParameters.SynchronizeWithVerticalRetrace ? PresentInterval.One : PresentInterval.Immediate,
-                                                         DeviceWindowHandle = MainWindow.NativeWindow,
-                                                         RenderTargetUsage = Usage.BackBuffer | Usage.RenderTargetOutput
-                                                     }
-                                             };
+                        var deviceInfo = CreateGraphicsDeviceInformation(prefferedParameters, graphicsAdapter, featureLevel);
 
                         // Hardcoded format and refresh rate...
                         // This is a workaround to allow this code to work inside the emulator


### PR DESCRIPTION
I have used the same approach as it was for WinRT - the fix was implemented so that the applications will work in emulator. As WinRT emulator works over RDP (it creates second user session on the same machine) - the same approach is applicable to Desktop platform.
Code duplication was slightly reduced while keeping its readability.

When Part 1 will be accepted - proceed to the Part 2 (it will be sent as a separate pull request)
