### PR TITLE
[DirectWrite.Samples] Fixed CustomLayout sample

### DIFF
--- a/Samples/DirectWrite/CustomLayout/FlowLayout.cs
+++ b/Samples/DirectWrite/CustomLayout/FlowLayout.cs
@@ -258,13 +258,16 @@ namespace CustomLayout
                 }
                 finally
                 {
-                    tries++;
-                    // Try again using a larger buffer.
-                    maxGlyphCount = EstimateGlyphCount(maxGlyphCount);
-                    int totalGlyphsArrayCount = glyphStart + maxGlyphCount;
+                    if (!isDone)
+                    {
+                        tries++;
+                        // Try again using a larger buffer.
+                        maxGlyphCount = EstimateGlyphCount(maxGlyphCount);
+                        int totalGlyphsArrayCount = glyphStart + maxGlyphCount;
 
-                    glyphProps = new ShapingGlyphProperties[maxGlyphCount];
-                    glyphIndices_ = new short[totalGlyphsArrayCount];
+                        glyphProps = new ShapingGlyphProperties[maxGlyphCount];
+                        glyphIndices_ = new short[totalGlyphsArrayCount];
+                    }
                 }
                 if (isDone)
                     break;
@@ -563,7 +566,7 @@ namespace CustomLayout
             {
                 spanIndices[i] = spanStart + i;
             }
-            
+
             if (spanCount <= 1)
                 return;
 


### PR DESCRIPTION
The algorithm of determining glyph proprieties was implemented to perform 2 tries. After the first try - it resets computed parameters in preparation for the second try (look in diff), but if the first try is successful - the parameters remain reset which leads to "invalid arg" error on the next DW API call - this pull request fixes the issue.
