### PR TITLE
[SharpDX] Add Up, Down, Left, Right, ForwardRH, ForwardLH, BackwardRH and BackwardLH to Vector3

### DIFF
--- a/Source/SharpDX/Vector3.cs
+++ b/Source/SharpDX/Vector3.cs
@@ -92,6 +92,46 @@ namespace SharpDX
         public static readonly Vector3 One = new Vector3(1.0f, 1.0f, 1.0f);
 
         /// <summary>
+        /// A unit <see cref="SharpDX.Vector3"/> designating up (0, 1, 0).
+        /// </summary>
+        public static readonly Vector3 Up = new Vector3(0.0f, 1.0f, 0.0f);
+
+        /// <summary>
+        /// A unit <see cref="SharpDX.Vector3"/> designating down (0, -1, 0).
+        /// </summary>
+        public static readonly Vector3 Down = new Vector3(0.0f, -1.0f, 0.0f);
+
+        /// <summary>
+        /// A unit <see cref="SharpDX.Vector3"/> designating left (-1, 0, 0).
+        /// </summary>
+        public static readonly Vector3 Left = new Vector3(-1.0f, 0.0f, 0.0f);
+
+        /// <summary>
+        /// A unit <see cref="SharpDX.Vector3"/> designating right (1, 0, 0).
+        /// </summary>
+        public static readonly Vector3 Right = new Vector3(1.0f, 0.0f, 0.0f);
+
+        /// <summary>
+        /// A unit <see cref="SharpDX.Vector3"/> designating forward in a right-handed coordinate system (0, 0, -1).
+        /// </summary>
+        public static readonly Vector3 ForwardRH = new Vector3(0.0f, 0.0f, -1.0f);
+
+        /// <summary>
+        /// A unit <see cref="SharpDX.Vector3"/> designating forward in a left-handed coordinate system (0, 0, 1).
+        /// </summary>
+        public static readonly Vector3 ForwardLH = new Vector3(0.0f, 0.0f, 1.0f);
+
+        /// <summary>
+        /// A unit <see cref="SharpDX.Vector3"/> designating backward in a right-handed coordinate system (0, 0, 1).
+        /// </summary>
+        public static readonly Vector3 BackwardRH = new Vector3(0.0f, 0.0f, 1.0f);
+
+        /// <summary>
+        /// A unit <see cref="SharpDX.Vector3"/> designating backward in a left-handed coordinate system (0, 0, -1).
+        /// </summary>
+        public static readonly Vector3 BackwardLH = new Vector3(0.0f, 0.0f, -1.0f);
+
+        /// <summary>
         /// The X component of the vector.
         /// </summary>
         public float X;


### PR DESCRIPTION
I think these are useful, even with the slight added complication of having to provide LH and RH versions of Forward and Backward. 

(In theory, we should all be able to use UnitX, UnitY and UnitZ to do the same thing as these properties, but sometimes it's nice to have a helping hand.)
