### PR TITLE
[WIC] Enable SharpDX.WIC.Bitmap.Lock methods for Windows 8 build

### DIFF
--- a/Source/SharpDX.Direct2D1/WIC/Bitmap.cs
+++ b/Source/SharpDX.Direct2D1/WIC/Bitmap.cs
@@ -116,6 +116,40 @@ namespace SharpDX.WIC
             return new Bitmap(factory, width, height, pixelFormat, new DataRectangle((IntPtr)Interop.Fixed(pixelDatas), stride));
         }
 
+        /// <summary>	
+        /// <p>Provides access to a rectangular area of the bitmap.</p>	
+        /// </summary>	
+        /// <param name="flags"><dd>  <p>The access mode you wish to obtain for the lock. This is a bitwise combination of <strong><see cref="SharpDX.WIC.BitmapLockFlags"/></strong> for read, write, or read and write access.</p> <table> <tr><th>Value</th><th>Meaning</th></tr> <tr><td><dl> <dt><strong><see cref="SharpDX.WIC.BitmapLockFlags.Read"/></strong></dt> </dl> </td><td> <p>The read access lock.</p> </td></tr> <tr><td><dl> <dt><strong><see cref="SharpDX.WIC.BitmapLockFlags.Write"/></strong></dt> </dl> </td><td> <p>The write access lock.</p> </td></tr> </table> <p>?</p> </dd></param>	
+        /// <returns><dd>  <p>A reference that receives the locked memory location.</p> </dd></returns>	
+        /// <remarks>	
+        /// <p>Locks are exclusive for writing but can be shared for reading. You cannot call <strong>CopyPixels</strong> while the <strong><see cref="SharpDX.WIC.Bitmap"/></strong> is locked for writing. Doing so will return an error, since locks are exclusive.</p>	
+        /// </remarks>	
+        /// <msdn-id>ee690187</msdn-id>	
+        /// <unmanaged>HRESULT IWICBitmap::Lock([In, Optional] const WICRect* prcLock,[In] WICBitmapLockFlags flags,[Out] IWICBitmapLock** ppILock)</unmanaged>	
+        /// <unmanaged-short>IWICBitmap::Lock</unmanaged-short>	
+        public SharpDX.WIC.BitmapLock Lock(SharpDX.WIC.BitmapLockFlags flags)
+        {
+            return Lock(IntPtr.Zero, flags);
+        }
+
+        /// <summary>	
+        /// <p>Provides access to a rectangular area of the bitmap.</p>	
+        /// </summary>	
+        /// <param name="rcLockRef"><dd>  <p>The rectangle to be accessed.</p> </dd></param>	
+        /// <param name="flags"><dd>  <p>The access mode you wish to obtain for the lock. This is a bitwise combination of <strong><see cref="SharpDX.WIC.BitmapLockFlags"/></strong> for read, write, or read and write access.</p> <table> <tr><th>Value</th><th>Meaning</th></tr> <tr><td><dl> <dt><strong><see cref="SharpDX.WIC.BitmapLockFlags.Read"/></strong></dt> </dl> </td><td> <p>The read access lock.</p> </td></tr> <tr><td><dl> <dt><strong><see cref="SharpDX.WIC.BitmapLockFlags.Write"/></strong></dt> </dl> </td><td> <p>The write access lock.</p> </td></tr> </table> <p>?</p> </dd></param>	
+        /// <returns><dd>  <p>A reference that receives the locked memory location.</p> </dd></returns>	
+        /// <remarks>	
+        /// <p>Locks are exclusive for writing but can be shared for reading. You cannot call <strong>CopyPixels</strong> while the <strong><see cref="SharpDX.WIC.Bitmap"/></strong> is locked for writing. Doing so will return an error, since locks are exclusive.</p>	
+        /// </remarks>	
+        /// <msdn-id>ee690187</msdn-id>	
+        /// <unmanaged>HRESULT IWICBitmap::Lock([In, Optional] const WICRect* prcLock,[In] WICBitmapLockFlags flags,[Out] IWICBitmapLock** ppILock)</unmanaged>	
+        /// <unmanaged-short>IWICBitmap::Lock</unmanaged-short>	
+        public unsafe SharpDX.WIC.BitmapLock Lock(Rectangle rcLockRef, SharpDX.WIC.BitmapLockFlags flags)
+        {
+            rcLockRef.MakeXYAndWidthHeight();
+            return this.Lock(new IntPtr(&rcLockRef), flags);
+        }
+
 #if !WIN8METRO
         /// <summary>
         /// Initializes a new instance of the <see cref="Bitmap"/> class from a <see cref="Icon"/>.
@@ -150,40 +184,6 @@ namespace SharpDX.WIC
                 DeleteObject(hBitmap);
                 Marshal.FreeHGlobal(hPalette);
             }
-        }
-
-        /// <summary>	
-        /// <p>Provides access to a rectangular area of the bitmap.</p>	
-        /// </summary>	
-        /// <param name="flags"><dd>  <p>The access mode you wish to obtain for the lock. This is a bitwise combination of <strong><see cref="SharpDX.WIC.BitmapLockFlags"/></strong> for read, write, or read and write access.</p> <table> <tr><th>Value</th><th>Meaning</th></tr> <tr><td><dl> <dt><strong><see cref="SharpDX.WIC.BitmapLockFlags.Read"/></strong></dt> </dl> </td><td> <p>The read access lock.</p> </td></tr> <tr><td><dl> <dt><strong><see cref="SharpDX.WIC.BitmapLockFlags.Write"/></strong></dt> </dl> </td><td> <p>The write access lock.</p> </td></tr> </table> <p>?</p> </dd></param>	
-        /// <returns><dd>  <p>A reference that receives the locked memory location.</p> </dd></returns>	
-        /// <remarks>	
-        /// <p>Locks are exclusive for writing but can be shared for reading. You cannot call <strong>CopyPixels</strong> while the <strong><see cref="SharpDX.WIC.Bitmap"/></strong> is locked for writing. Doing so will return an error, since locks are exclusive.</p>	
-        /// </remarks>	
-        /// <msdn-id>ee690187</msdn-id>	
-        /// <unmanaged>HRESULT IWICBitmap::Lock([In, Optional] const WICRect* prcLock,[In] WICBitmapLockFlags flags,[Out] IWICBitmapLock** ppILock)</unmanaged>	
-        /// <unmanaged-short>IWICBitmap::Lock</unmanaged-short>	
-        public SharpDX.WIC.BitmapLock Lock(SharpDX.WIC.BitmapLockFlags flags)
-        {
-            return Lock(IntPtr.Zero, flags);
-        }
-
-        /// <summary>	
-        /// <p>Provides access to a rectangular area of the bitmap.</p>	
-        /// </summary>	
-        /// <param name="rcLockRef"><dd>  <p>The rectangle to be accessed.</p> </dd></param>	
-        /// <param name="flags"><dd>  <p>The access mode you wish to obtain for the lock. This is a bitwise combination of <strong><see cref="SharpDX.WIC.BitmapLockFlags"/></strong> for read, write, or read and write access.</p> <table> <tr><th>Value</th><th>Meaning</th></tr> <tr><td><dl> <dt><strong><see cref="SharpDX.WIC.BitmapLockFlags.Read"/></strong></dt> </dl> </td><td> <p>The read access lock.</p> </td></tr> <tr><td><dl> <dt><strong><see cref="SharpDX.WIC.BitmapLockFlags.Write"/></strong></dt> </dl> </td><td> <p>The write access lock.</p> </td></tr> </table> <p>?</p> </dd></param>	
-        /// <returns><dd>  <p>A reference that receives the locked memory location.</p> </dd></returns>	
-        /// <remarks>	
-        /// <p>Locks are exclusive for writing but can be shared for reading. You cannot call <strong>CopyPixels</strong> while the <strong><see cref="SharpDX.WIC.Bitmap"/></strong> is locked for writing. Doing so will return an error, since locks are exclusive.</p>	
-        /// </remarks>	
-        /// <msdn-id>ee690187</msdn-id>	
-        /// <unmanaged>HRESULT IWICBitmap::Lock([In, Optional] const WICRect* prcLock,[In] WICBitmapLockFlags flags,[Out] IWICBitmapLock** ppILock)</unmanaged>	
-        /// <unmanaged-short>IWICBitmap::Lock</unmanaged-short>	
-        public unsafe SharpDX.WIC.BitmapLock Lock(Rectangle rcLockRef, SharpDX.WIC.BitmapLockFlags flags)
-        {
-            rcLockRef.MakeXYAndWidthHeight();
-            return this.Lock(new IntPtr(&rcLockRef), flags);
         }
 
         private static IntPtr ConvertToHPALETTE(ColorPalette colorPalette)


### PR DESCRIPTION
This method is supported in both Desktop and Windows Store apps.

http://msdn.microsoft.com/en-us/library/windows/desktop/ee690187.aspx

And I need this for reading pixels from bitmaps :)
