### PR TITLE
ContentManager Bug Fix

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.Graphics/GraphicsResourceContentReaderBase.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Graphics/GraphicsResourceContentReaderBase.cs
@@ -40,9 +40,9 @@ namespace SharpDX.Toolkit.Graphics
             if (service.GraphicsDevice == null)
                 throw new InvalidOperationException("GraphicsDevice is not initialized");
 
-            return ReadContent(readerManager, service.GraphicsDevice, assetName, stream);
+            return ReadContent(readerManager, service.GraphicsDevice, assetName, stream, options);
         }
 
-        protected abstract T ReadContent(IContentManager readerManager, GraphicsDevice device, string assetName, Stream stream, object options = null);
+        protected abstract T ReadContent(IContentManager readerManager, GraphicsDevice device, string assetName, Stream stream, object options);
     }
 }

--- a/Source/Toolkit/SharpDX.Toolkit/Content/ContentManager.cs
+++ b/Source/Toolkit/SharpDX.Toolkit/Content/ContentManager.cs
@@ -308,7 +308,7 @@ namespace SharpDX.Toolkit.Content
 
                     // Rewind position every time we try to load an asset
                     stream.Position = startPosition;
-                    result = contentReader.ReadContent(this, assetNameWithExtension, stream, out keepStreamOpen);
+                    result = contentReader.ReadContent(this, assetNameWithExtension, stream, out keepStreamOpen, options);
                     stream.Position = startPosition;
                 }
                 else
@@ -322,7 +322,7 @@ namespace SharpDX.Toolkit.Content
                     foreach (IContentReader registeredContentReader in readers)
                     {
                         // Rewind position every time we try to load an asset
-                        result = registeredContentReader.ReadContent(this, assetNameWithExtension, stream, out keepStreamOpen);
+                        result = registeredContentReader.ReadContent(this, assetNameWithExtension, stream, out keepStreamOpen, options);
                         stream.Position = startPosition;
                         if (result != null) break;
                     }

--- a/Source/Toolkit/SharpDX.Toolkit/Content/IContentReader.cs
+++ b/Source/Toolkit/SharpDX.Toolkit/Content/IContentReader.cs
@@ -36,6 +36,6 @@ namespace SharpDX.Toolkit.Content
         /// <param name="keepStreamOpen"><c>true</c> to keep the stream opened after the content was read, otherwise the stream will be closed after if this content reader succeeded to read the data.</param>
         /// <param name="options">The options passed to the content manager.</param>
         /// <returns>The data decoded from the stream, or null if the kind of asset is not supported by this content reader.</returns>
-        object ReadContent(IContentManager contentManager, string assetName, Stream stream, out bool keepStreamOpen, object options = null);
+        object ReadContent(IContentManager contentManager, string assetName, Stream stream, out bool keepStreamOpen, object options);
     }
 }


### PR DESCRIPTION
Fixed a bug where load options were not being passed through to IContentReader.ReadContent in ContentManager.LoadAssetWithDynamicContentReader
