### PR TITLE
[SharpDX] Fix comment for Matrix3x2.TranslationVector

### DIFF
--- a/Source/SharpDX/Matrix3x2.cs
+++ b/Source/SharpDX/Matrix3x2.cs
@@ -166,7 +166,7 @@ namespace SharpDX
         }
 
         /// <summary>
-        /// Gets or sets the translation of the matrix; that is M41, M42.
+        /// Gets or sets the translation of the matrix; that is M31, M32.
         /// </summary>
         public Vector2 TranslationVector
         {


### PR DESCRIPTION
Just fixing a comment. Looks like a copy/paste error.
