### PR TITLE
ModelCompiler Bug Fix

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.Compiler/Model/ModelCompiler.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Compiler/Model/ModelCompiler.cs
@@ -591,7 +591,7 @@ namespace SharpDX.Toolkit.Graphics
                 {
                     if (assimpMesh.HasVertexColors(i))
                     {
-                        layout.Add(VertexElement.Normal(localIndex, Format.R32G32B32A32_Float, vertexBufferElementSize));
+                        layout.Add(VertexElement.Color(localIndex, Format.R32G32B32A32_Float, vertexBufferElementSize));
                         vertexBufferElementSize += Utilities.SizeOf<SharpDX.Color4>();
                         localIndex++;
                     }


### PR DESCRIPTION
Fixed a bug where the ModelCompiler would create a vertex layout with
duplicated Normal0 semantics when Assimp.Net loaded a Scene which
included both Vertex Colors and Normal Data.
