### PR TITLE
[DirectWrite] Add implicit casts for DirectWrite.Matrix

### DIFF
--- a/Source/SharpDX.Direct2D1/DirectWrite/Matrix.cs
+++ b/Source/SharpDX.Direct2D1/DirectWrite/Matrix.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2010-2013 SharpDX - Alexandre Mutel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SharpDX.DirectWrite
+{
+    /// <summary>
+    /// DirectWrite Matrix. Supports implicit cast to/from <see cref="SharpDX.Matrix3x2"/>.
+    /// </summary>
+    public partial struct Matrix
+    {
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="DirectWrite.Matrix"/> to <see cref="SharpDX.Matrix3x2"/>.
+        /// </summary>
+        /// <param name="matrix">The matrix.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator SharpDX.Matrix3x2(Matrix matrix)
+        {
+            return new Matrix3x2()
+            {
+                M11 = matrix.M11,
+                M12 = matrix.M12,
+                M21 = matrix.M21,
+                M22 = matrix.M22,
+                M31 = matrix.Dx,
+                M32 = matrix.Dy
+            };
+        }
+
+        /// <summary>
+        /// Performs an implicit conversion from <see cref="SharpDX.Matrix3x2"/> to <see cref="DirectWrite.Matrix"/>.
+        /// </summary>
+        /// <param name="matrix3x2">The matrix3x2.</param>
+        /// <returns>The result of the conversion.</returns>
+        public static implicit operator Matrix(SharpDX.Matrix3x2 matrix3x2)
+        {
+            return new Matrix()
+            {
+                M11 = matrix3x2.M11,
+                M12 = matrix3x2.M12,
+                M21 = matrix3x2.M21,
+                M22 = matrix3x2.M22,
+                Dx = matrix3x2.M31,
+                Dy = matrix3x2.M32
+            };
+        }
+    }
+}

--- a/Source/SharpDX.Direct2D1/SharpDX.Direct2D1.csproj
+++ b/Source/SharpDX.Direct2D1/SharpDX.Direct2D1.csproj
@@ -34,6 +34,7 @@
     <Compile Include="ComputeTransform.cs" />
     <Compile Include="ComputeTransformNative.cs" />
     <Compile Include="ComputeTransformShadow.cs" />
+    <Compile Include="DirectWrite\Matrix.cs" />
     <Compile Include="DirectWrite\TextAnalyzer1.cs" />
     <Compile Include="DirectWrite\TextAnalysisSource1Shadow.cs" />
     <Compile Include="DirectWrite\TextAnalysisSource1.cs" />


### PR DESCRIPTION
SharpDX.Matrix3x2 and DirectWrite.Matrix are different structures but represent the same thing. This makes it easy to use a single matrix for both cases.
