### PR TITLE
[SharpDX] Reduce duplicate lerp code and use MathUtil.Lerp() everywhere

### DIFF
--- a/Source/SharpDX/Color.cs
+++ b/Source/SharpDX/Color.cs
@@ -654,16 +654,14 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the linear interpolation of the two colors.</param>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static void Lerp(ref Color start, ref Color end, float amount, out Color result)
         {
-            result.A = (byte)(start.A + amount * (end.A - start.A));
-            result.R = (byte)(start.R + amount * (end.R - start.R));
-            result.G = (byte)(start.G + amount * (end.G - start.G));
-            result.B = (byte)(start.B + amount * (end.B - start.B));
+            result.R = MathUtil.Lerp(start.R, end.R, amount);
+            result.G = MathUtil.Lerp(start.G, end.G, amount);
+            result.B = MathUtil.Lerp(start.B, end.B, amount);
+            result.A = MathUtil.Lerp(start.A, end.A, amount);
         }
 
         /// <summary>
@@ -674,17 +672,13 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <returns>The linear interpolation of the two colors.</returns>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static Color Lerp(Color start, Color end, float amount)
         {
-            return new Color(
-                (byte)(start.R + amount * (end.R - start.R)),
-                (byte)(start.G + amount * (end.G - start.G)),
-                (byte)(start.B + amount * (end.B - start.B)),
-                (byte)(start.A + amount * (end.A - start.A)));
+            Color result;
+            Lerp(ref start, ref end, amount, out result);
+            return result;
         }
 
         /// <summary>
@@ -699,10 +693,7 @@ namespace SharpDX
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
 
-            result.A = (byte)(start.A + ((end.A - start.A) * amount));
-            result.R = (byte)(start.R + ((end.R - start.R) * amount));
-            result.G = (byte)(start.G + ((end.G - start.G) * amount));
-            result.B = (byte)(start.B + ((end.B - start.B) * amount));
+            Lerp(ref start, ref end, amount, out result);
         }
 
         /// <summary>
@@ -714,22 +705,17 @@ namespace SharpDX
         /// <returns>The cubic interpolation of the two colors.</returns>
         public static Color SmoothStep(Color start, Color end, float amount)
         {
-            amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
-            amount = (amount * amount) * (3.0f - (2.0f * amount));
-
-            return new Color(                
-                (byte)(start.R + ((end.R - start.R) * amount)),
-                (byte)(start.G + ((end.G - start.G) * amount)),
-                (byte)(start.B + ((end.B - start.B) * amount)),
-                (byte)(start.A + ((end.A - start.A) * amount)));
+            Color result;
+            SmoothStep(ref start, ref end, amount, out result);
+            return result;
         }
 
         /// <summary>
-        /// Returns a color containing the smallest components of the specified colorss.
+        /// Returns a color containing the smallest components of the specified colors.
         /// </summary>
         /// <param name="left">The first source color.</param>
         /// <param name="right">The second source color.</param>
-        /// <param name="result">When the method completes, contains an new color composed of the largest components of the source colorss.</param>
+        /// <param name="result">When the method completes, contains an new color composed of the largest components of the source colors.</param>
         public static void Max(ref Color left, ref Color right, out Color result)
         {
             result.A = (left.A > right.A) ? left.A : right.A;
@@ -854,7 +840,7 @@ namespace SharpDX
         /// <summary>
         /// Assert a color (return it unchanged).
         /// </summary>
-        /// <param name="value">The color to assert (unchange).</param>
+        /// <param name="value">The color to assert (unchanged).</param>
         /// <returns>The asserted (unchanged) color.</returns>
         public static Color operator +(Color value)
         {
@@ -977,7 +963,7 @@ namespace SharpDX
         }
 
         /// <summary>
-        /// Performs an explicit conversion from <see cref="SharpDX.Color"/> to <see cref="SharpDX.Color4"/>.
+        /// Performs an implicit conversion from <see cref="SharpDX.Color"/> to <see cref="SharpDX.Color4"/>.
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>

--- a/Source/SharpDX/Color3.cs
+++ b/Source/SharpDX/Color3.cs
@@ -403,15 +403,13 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the linear interpolation of the two colors.</param>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static void Lerp(ref Color3 start, ref Color3 end, float amount, out Color3 result)
         {
-            result.Red = start.Red + amount * (end.Red - start.Red);
-            result.Green = start.Green + amount * (end.Green - start.Green);
-            result.Blue = start.Blue + amount * (end.Blue - start.Blue);
+            result.Red = MathUtil.Lerp(start.Red, end.Red, amount);
+            result.Green = MathUtil.Lerp(start.Green, end.Green, amount);
+            result.Blue = MathUtil.Lerp(start.Blue, end.Blue, amount);
         }
 
         /// <summary>
@@ -422,16 +420,13 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <returns>The linear interpolation of the two colors.</returns>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static Color3 Lerp(Color3 start, Color3 end, float amount)
         {
-            return new Color3(
-                start.Red + amount * (end.Red - start.Red),
-                start.Green + amount * (end.Green - start.Green),
-                start.Blue + amount * (end.Blue - start.Blue));
+            Color3 result;
+            Lerp(ref start, ref end, amount, out result);
+            return result;
         }
 
         /// <summary>
@@ -446,9 +441,7 @@ namespace SharpDX
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
 
-            result.Red = start.Red + ((end.Red - start.Red) * amount);
-            result.Green = start.Green + ((end.Green - start.Green) * amount);
-            result.Blue = start.Blue + ((end.Blue - start.Blue) * amount);
+            Lerp(ref start, ref end, amount, out result);
         }
 
         /// <summary>
@@ -460,13 +453,9 @@ namespace SharpDX
         /// <returns>The cubic interpolation of the two colors.</returns>
         public static Color3 SmoothStep(Color3 start, Color3 end, float amount)
         {
-            amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
-            amount = (amount * amount) * (3.0f - (2.0f * amount));
-
-            return new Color3(
-                start.Red + ((end.Red - start.Red) * amount),
-                start.Green + ((end.Green - start.Green) * amount),
-                start.Blue + ((end.Blue - start.Blue) * amount));
+            Color3 result;
+            SmoothStep(ref start, ref end, amount, out result);
+            return result;
         }
 
         /// <summary>
@@ -687,7 +676,7 @@ namespace SharpDX
         }
 
         /// <summary>
-        /// Performs an explicit conversion from <see cref="SharpDX.Color3"/> to <see cref="SharpDX.Vector3"/>.
+        /// Performs an implicit conversion from <see cref="SharpDX.Color3"/> to <see cref="SharpDX.Vector3"/>.
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
@@ -697,7 +686,7 @@ namespace SharpDX
         }
 
         /// <summary>
-        /// Performs an explicit conversion from <see cref="SharpDX.Vector3"/> to <see cref="SharpDX.Color3"/>.
+        /// Performs an implicit conversion from <see cref="SharpDX.Vector3"/> to <see cref="SharpDX.Color3"/>.
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>

--- a/Source/SharpDX/Color4.cs
+++ b/Source/SharpDX/Color4.cs
@@ -493,16 +493,14 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the linear interpolation of the two colors.</param>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static void Lerp(ref Color4 start, ref Color4 end, float amount, out Color4 result)
         {
-            result.Alpha = start.Alpha + amount * (end.Alpha - start.Alpha);
-            result.Red = start.Red + amount * (end.Red - start.Red);
-            result.Green = start.Green + amount * (end.Green - start.Green);
-            result.Blue = start.Blue + amount * (end.Blue - start.Blue);
+            result.Red = MathUtil.Lerp(start.Red, end.Red, amount);
+            result.Green = MathUtil.Lerp(start.Green, end.Green, amount);
+            result.Blue = MathUtil.Lerp(start.Blue, end.Blue, amount);
+            result.Alpha = MathUtil.Lerp(start.Alpha, end.Alpha, amount);
         }
 
         /// <summary>
@@ -513,17 +511,13 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <returns>The linear interpolation of the two colors.</returns>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static Color4 Lerp(Color4 start, Color4 end, float amount)
         {
-            return new Color4(
-                start.Red + amount * (end.Red - start.Red),
-                start.Green + amount * (end.Green - start.Green),
-                start.Blue + amount * (end.Blue - start.Blue),
-                start.Alpha + amount * (end.Alpha - start.Alpha));
+            Color4 result;
+            Lerp(ref start, ref end, amount, out result);
+            return result;
         }
 
         /// <summary>
@@ -538,10 +532,7 @@ namespace SharpDX
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
 
-            result.Alpha = start.Alpha + ((end.Alpha - start.Alpha) * amount);
-            result.Red = start.Red + ((end.Red - start.Red) * amount);
-            result.Green = start.Green + ((end.Green - start.Green) * amount);
-            result.Blue = start.Blue + ((end.Blue - start.Blue) * amount);
+            Lerp(ref start, ref end, amount, out result);
         }
 
         /// <summary>
@@ -553,14 +544,9 @@ namespace SharpDX
         /// <returns>The cubic interpolation of the two colors.</returns>
         public static Color4 SmoothStep(Color4 start, Color4 end, float amount)
         {
-            amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
-            amount = (amount * amount) * (3.0f - (2.0f * amount));
-
-            return new Color4(                
-                start.Red + ((end.Red - start.Red) * amount),
-                start.Green + ((end.Green - start.Green) * amount),
-                start.Blue + ((end.Blue - start.Blue) * amount),
-                start.Alpha + ((end.Alpha - start.Alpha) * amount));
+            Color4 result;
+            SmoothStep(ref start, ref end, amount, out result);
+            return result;
         }
 
         /// <summary>
@@ -797,7 +783,7 @@ namespace SharpDX
         }
 
         /// <summary>
-        /// Performs an explicit conversion from <see cref="SharpDX.Color4"/> to <see cref="SharpDX.Vector4"/>.
+        /// Performs an implicit conversion from <see cref="SharpDX.Color4"/> to <see cref="SharpDX.Vector4"/>.
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>

--- a/Source/SharpDX/ColorBGRA.cs
+++ b/Source/SharpDX/ColorBGRA.cs
@@ -612,16 +612,14 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the linear interpolation of the two colors.</param>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static void Lerp(ref ColorBGRA start, ref ColorBGRA end, float amount, out ColorBGRA result)
         {
-            result.A = (byte)(start.A + amount * (end.A - start.A));
-            result.R = (byte)(start.R + amount * (end.R - start.R));
-            result.G = (byte)(start.G + amount * (end.G - start.G));
-            result.B = (byte)(start.B + amount * (end.B - start.B));
+            result.B = MathUtil.Lerp(start.B, end.B, amount);
+            result.G = MathUtil.Lerp(start.G, end.G, amount);
+            result.R = MathUtil.Lerp(start.R, end.R, amount);
+            result.A = MathUtil.Lerp(start.A, end.A, amount);
         }
 
         /// <summary>
@@ -632,17 +630,13 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <returns>The linear interpolation of the two colors.</returns>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static ColorBGRA Lerp(ColorBGRA start, ColorBGRA end, float amount)
         {
-            return new ColorBGRA(
-                (byte)(start.R + amount * (end.R - start.R)),
-                (byte)(start.G + amount * (end.G - start.G)),
-                (byte)(start.B + amount * (end.B - start.B)),
-                (byte)(start.A + amount * (end.A - start.A)));
+            ColorBGRA result;
+            Lerp(ref start, ref end, amount, out result);
+            return result;
         }
 
         /// <summary>
@@ -657,10 +651,7 @@ namespace SharpDX
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
 
-            result.A = (byte)(start.A + ((end.A - start.A) * amount));
-            result.R = (byte)(start.R + ((end.R - start.R) * amount));
-            result.G = (byte)(start.G + ((end.G - start.G) * amount));
-            result.B = (byte)(start.B + ((end.B - start.B) * amount));
+            Lerp(ref start, ref end, amount, out result);
         }
 
         /// <summary>
@@ -675,11 +666,9 @@ namespace SharpDX
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
 
-            return new ColorBGRA(                
-                (byte)(start.R + ((end.R - start.R) * amount)),
-                (byte)(start.G + ((end.G - start.G) * amount)),
-                (byte)(start.B + ((end.B - start.B) * amount)),
-                (byte)(start.A + ((end.A - start.A) * amount)));
+            ColorBGRA result;
+            SmoothStep(ref start, ref end, amount, out result);
+            return result;
         }
 
         /// <summary>
@@ -976,7 +965,7 @@ namespace SharpDX
         }
 
         /// <summary>
-        /// Performs an explicit conversion from <see cref="SharpDX.Color"/> to <see cref="SharpDX.ColorBGRA"/>.
+        /// Performs an implicit conversion from <see cref="SharpDX.Color"/> to <see cref="SharpDX.ColorBGRA"/>.
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>
@@ -986,7 +975,7 @@ namespace SharpDX
         }
 
         /// <summary>
-        /// Performs an explicit conversion from <see cref="SharpDX.ColorBGRA"/> to <see cref="SharpDX.Color"/>.
+        /// Performs an implicit conversion from <see cref="SharpDX.ColorBGRA"/> to <see cref="SharpDX.Color"/>.
         /// </summary>
         /// <param name="value">The value.</param>
         /// <returns>The result of the conversion.</returns>

--- a/Source/SharpDX/MathUtil.cs
+++ b/Source/SharpDX/MathUtil.cs
@@ -260,9 +260,25 @@ namespace SharpDX
         /// <returns>The result of linear interpolation of values based on the amount.</returns>
         public static float Lerp(float from, float to, float amount)
         {
-            return (1 - amount) * from + amount * to; 
+            return (1 - amount) * from + amount * to;
         }
-        
+
+        /// <summary>
+        /// Interpolates between two values using a linear function by a given amount.
+        /// </summary>
+        /// <remarks>
+        /// See http://www.encyclopediaofmath.org/index.php/Linear_interpolation and
+        /// http://fgiesen.wordpress.com/2012/08/15/linear-interpolation-past-present-and-future/
+        /// </remarks>
+        /// <param name="from">Value to interpolate from.</param>
+        /// <param name="to">Value to interpolate to.</param>
+        /// <param name="amount">Interpolation amount.</param>
+        /// <returns>The result of linear interpolation of values based on the amount.</returns>
+        public static byte Lerp(byte from, byte to, float amount)
+        {
+            return (byte)Lerp((float)from, (float)to, amount);
+        }
+
         /// <summary>
         /// Calculates the modulo of the specified value.
         /// </summary>

--- a/Source/SharpDX/Matrix.cs
+++ b/Source/SharpDX/Matrix.cs
@@ -1152,28 +1152,26 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the linear interpolation of the two matrices.</param>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static void Lerp(ref Matrix start, ref Matrix end, float amount, out Matrix result)
         {
-            result.M11 = start.M11 + ((end.M11 - start.M11) * amount);
-            result.M12 = start.M12 + ((end.M12 - start.M12) * amount);
-            result.M13 = start.M13 + ((end.M13 - start.M13) * amount);
-            result.M14 = start.M14 + ((end.M14 - start.M14) * amount);
-            result.M21 = start.M21 + ((end.M21 - start.M21) * amount);
-            result.M22 = start.M22 + ((end.M22 - start.M22) * amount);
-            result.M23 = start.M23 + ((end.M23 - start.M23) * amount);
-            result.M24 = start.M24 + ((end.M24 - start.M24) * amount);
-            result.M31 = start.M31 + ((end.M31 - start.M31) * amount);
-            result.M32 = start.M32 + ((end.M32 - start.M32) * amount);
-            result.M33 = start.M33 + ((end.M33 - start.M33) * amount);
-            result.M34 = start.M34 + ((end.M34 - start.M34) * amount);
-            result.M41 = start.M41 + ((end.M41 - start.M41) * amount);
-            result.M42 = start.M42 + ((end.M42 - start.M42) * amount);
-            result.M43 = start.M43 + ((end.M43 - start.M43) * amount);
-            result.M44 = start.M44 + ((end.M44 - start.M44) * amount);
+            result.M11 = MathUtil.Lerp(start.M11, end.M11, amount);
+            result.M12 = MathUtil.Lerp(start.M12, end.M12, amount);
+            result.M13 = MathUtil.Lerp(start.M13, end.M13, amount);
+            result.M14 = MathUtil.Lerp(start.M14, end.M14, amount);
+            result.M21 = MathUtil.Lerp(start.M21, end.M21, amount);
+            result.M22 = MathUtil.Lerp(start.M22, end.M22, amount);
+            result.M23 = MathUtil.Lerp(start.M23, end.M23, amount);
+            result.M24 = MathUtil.Lerp(start.M24, end.M24, amount);
+            result.M31 = MathUtil.Lerp(start.M31, end.M31, amount);
+            result.M32 = MathUtil.Lerp(start.M32, end.M32, amount);
+            result.M33 = MathUtil.Lerp(start.M33, end.M33, amount);
+            result.M34 = MathUtil.Lerp(start.M34, end.M34, amount);
+            result.M41 = MathUtil.Lerp(start.M41, end.M41, amount);
+            result.M42 = MathUtil.Lerp(start.M42, end.M42, amount);
+            result.M43 = MathUtil.Lerp(start.M43, end.M43, amount);
+            result.M44 = MathUtil.Lerp(start.M44, end.M44, amount);
         }
 
         /// <summary>
@@ -1184,8 +1182,6 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <returns>The linear interpolation of the two matrices.</returns>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static Matrix Lerp(Matrix start, Matrix end, float amount)
@@ -1207,22 +1203,7 @@ namespace SharpDX
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
 
-            result.M11 = start.M11 + ((end.M11 - start.M11) * amount);
-            result.M12 = start.M12 + ((end.M12 - start.M12) * amount);
-            result.M13 = start.M13 + ((end.M13 - start.M13) * amount);
-            result.M14 = start.M14 + ((end.M14 - start.M14) * amount);
-            result.M21 = start.M21 + ((end.M21 - start.M21) * amount);
-            result.M22 = start.M22 + ((end.M22 - start.M22) * amount);
-            result.M23 = start.M23 + ((end.M23 - start.M23) * amount);
-            result.M24 = start.M24 + ((end.M24 - start.M24) * amount);
-            result.M31 = start.M31 + ((end.M31 - start.M31) * amount);
-            result.M32 = start.M32 + ((end.M32 - start.M32) * amount);
-            result.M33 = start.M33 + ((end.M33 - start.M33) * amount);
-            result.M34 = start.M34 + ((end.M34 - start.M34) * amount);
-            result.M41 = start.M41 + ((end.M41 - start.M41) * amount);
-            result.M42 = start.M42 + ((end.M42 - start.M42) * amount);
-            result.M43 = start.M43 + ((end.M43 - start.M43) * amount);
-            result.M44 = start.M44 + ((end.M44 - start.M44) * amount);
+            Lerp(ref start, ref end, amount, out result);
         }
 
         /// <summary>

--- a/Source/SharpDX/Matrix5x4.cs
+++ b/Source/SharpDX/Matrix5x4.cs
@@ -605,32 +605,30 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the linear interpolation of the two matrices.</param>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static void Lerp(ref Matrix5x4 start, ref Matrix5x4 end, float amount, out Matrix5x4 result)
         {
-            result.M11 = start.M11 + ((end.M11 - start.M11) * amount);
-            result.M12 = start.M12 + ((end.M12 - start.M12) * amount);
-            result.M13 = start.M13 + ((end.M13 - start.M13) * amount);
-            result.M14 = start.M14 + ((end.M14 - start.M14) * amount);
-            result.M21 = start.M21 + ((end.M21 - start.M21) * amount);
-            result.M22 = start.M22 + ((end.M22 - start.M22) * amount);
-            result.M23 = start.M23 + ((end.M23 - start.M23) * amount);
-            result.M24 = start.M24 + ((end.M24 - start.M24) * amount);
-            result.M31 = start.M31 + ((end.M31 - start.M31) * amount);
-            result.M32 = start.M32 + ((end.M32 - start.M32) * amount);
-            result.M33 = start.M33 + ((end.M33 - start.M33) * amount);
-            result.M34 = start.M34 + ((end.M34 - start.M34) * amount);
-            result.M41 = start.M41 + ((end.M41 - start.M41) * amount);
-            result.M42 = start.M42 + ((end.M42 - start.M42) * amount);
-            result.M43 = start.M43 + ((end.M43 - start.M43) * amount);
-            result.M44 = start.M44 + ((end.M44 - start.M44) * amount);
-            result.M51 = start.M51 + ((end.M51 - start.M51) * amount);
-            result.M52 = start.M52 + ((end.M52 - start.M52) * amount);
-            result.M53 = start.M53 + ((end.M53 - start.M53) * amount);
-            result.M54 = start.M54 + ((end.M54 - start.M54) * amount);
+            result.M11 = MathUtil.Lerp(start.M11, end.M11, amount);
+            result.M12 = MathUtil.Lerp(start.M12, end.M12, amount);
+            result.M13 = MathUtil.Lerp(start.M13, end.M13, amount);
+            result.M14 = MathUtil.Lerp(start.M14, end.M14, amount);
+            result.M21 = MathUtil.Lerp(start.M21, end.M21, amount);
+            result.M22 = MathUtil.Lerp(start.M22, end.M22, amount);
+            result.M23 = MathUtil.Lerp(start.M23, end.M23, amount);
+            result.M24 = MathUtil.Lerp(start.M24, end.M24, amount);
+            result.M31 = MathUtil.Lerp(start.M31, end.M31, amount);
+            result.M32 = MathUtil.Lerp(start.M32, end.M32, amount);
+            result.M33 = MathUtil.Lerp(start.M33, end.M33, amount);
+            result.M34 = MathUtil.Lerp(start.M34, end.M34, amount);
+            result.M41 = MathUtil.Lerp(start.M41, end.M41, amount);
+            result.M42 = MathUtil.Lerp(start.M42, end.M42, amount);
+            result.M43 = MathUtil.Lerp(start.M43, end.M43, amount);
+            result.M44 = MathUtil.Lerp(start.M44, end.M44, amount);
+            result.M51 = MathUtil.Lerp(start.M51, end.M51, amount);
+            result.M52 = MathUtil.Lerp(start.M52, end.M52, amount);
+            result.M53 = MathUtil.Lerp(start.M53, end.M53, amount);
+            result.M54 = MathUtil.Lerp(start.M54, end.M54, amount);
         }
 
         /// <summary>
@@ -641,8 +639,6 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <returns>The linear interpolation of the two matrices.</returns>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static Matrix5x4 Lerp(Matrix5x4 start, Matrix5x4 end, float amount)
@@ -664,26 +660,7 @@ namespace SharpDX
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
 
-            result.M11 = start.M11 + ((end.M11 - start.M11) * amount);
-            result.M12 = start.M12 + ((end.M12 - start.M12) * amount);
-            result.M13 = start.M13 + ((end.M13 - start.M13) * amount);
-            result.M14 = start.M14 + ((end.M14 - start.M14) * amount);
-            result.M21 = start.M21 + ((end.M21 - start.M21) * amount);
-            result.M22 = start.M22 + ((end.M22 - start.M22) * amount);
-            result.M23 = start.M23 + ((end.M23 - start.M23) * amount);
-            result.M24 = start.M24 + ((end.M24 - start.M24) * amount);
-            result.M31 = start.M31 + ((end.M31 - start.M31) * amount);
-            result.M32 = start.M32 + ((end.M32 - start.M32) * amount);
-            result.M33 = start.M33 + ((end.M33 - start.M33) * amount);
-            result.M34 = start.M34 + ((end.M34 - start.M34) * amount);
-            result.M41 = start.M41 + ((end.M41 - start.M41) * amount);
-            result.M42 = start.M42 + ((end.M42 - start.M42) * amount);
-            result.M43 = start.M43 + ((end.M43 - start.M43) * amount);
-            result.M44 = start.M44 + ((end.M44 - start.M44) * amount);
-            result.M51 = start.M51 + ((end.M51 - start.M51) * amount);
-            result.M52 = start.M52 + ((end.M52 - start.M52) * amount);
-            result.M53 = start.M53 + ((end.M53 - start.M53) * amount);
-            result.M54 = start.M54 + ((end.M54 - start.M54) * amount);
+            Lerp(ref start, ref end, amount, out result);
         }
 
         /// <summary>

--- a/Source/SharpDX/Vector2.cs
+++ b/Source/SharpDX/Vector2.cs
@@ -556,14 +556,12 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the linear interpolation of the two vectors.</param>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static void Lerp(ref Vector2 start, ref Vector2 end, float amount, out Vector2 result)
         {
-            result.X = start.X + ((end.X - start.X) * amount);
-            result.Y = start.Y + ((end.Y - start.Y) * amount);
+            result.X = MathUtil.Lerp(start.X, end.X, amount);
+            result.Y = MathUtil.Lerp(start.Y, end.Y, amount);
         }
 
         /// <summary>
@@ -574,8 +572,6 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <returns>The linear interpolation of the two vectors.</returns>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static Vector2 Lerp(Vector2 start, Vector2 end, float amount)
@@ -597,8 +593,7 @@ namespace SharpDX
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
 
-            result.X = start.X + ((end.X - start.X) * amount);
-            result.Y = start.Y + ((end.Y - start.Y) * amount);
+            Lerp(ref start, ref end, amount, out result);
         }
 
         /// <summary>

--- a/Source/SharpDX/Vector3.cs
+++ b/Source/SharpDX/Vector3.cs
@@ -678,15 +678,13 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the linear interpolation of the two vectors.</param>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static void Lerp(ref Vector3 start, ref Vector3 end, float amount, out Vector3 result)
         {
-            result.X = start.X + ((end.X - start.X) * amount);
-            result.Y = start.Y + ((end.Y - start.Y) * amount);
-            result.Z = start.Z + ((end.Z - start.Z) * amount);
+            result.X = MathUtil.Lerp(start.X, end.X, amount);
+            result.Y = MathUtil.Lerp(start.Y, end.Y, amount);
+            result.Z = MathUtil.Lerp(start.Z, end.Z, amount);
         }
 
         /// <summary>
@@ -697,8 +695,6 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <returns>The linear interpolation of the two vectors.</returns>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static Vector3 Lerp(Vector3 start, Vector3 end, float amount)
@@ -720,9 +716,7 @@ namespace SharpDX
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
 
-            result.X = start.X + ((end.X - start.X) * amount);
-            result.Y = start.Y + ((end.Y - start.Y) * amount);
-            result.Z = start.Z + ((end.Z - start.Z) * amount);
+            Lerp(ref start, ref end, amount, out result);
         }
 
         /// <summary>

--- a/Source/SharpDX/Vector4.cs
+++ b/Source/SharpDX/Vector4.cs
@@ -627,16 +627,14 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <param name="result">When the method completes, contains the linear interpolation of the two vectors.</param>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static void Lerp(ref Vector4 start, ref Vector4 end, float amount, out Vector4 result)
         {
-            result.X = start.X + ((end.X - start.X) * amount);
-            result.Y = start.Y + ((end.Y - start.Y) * amount);
-            result.Z = start.Z + ((end.Z - start.Z) * amount);
-            result.W = start.W + ((end.W - start.W) * amount);
+            result.X = MathUtil.Lerp(start.X, end.X, amount);
+            result.Y = MathUtil.Lerp(start.Y, end.Y, amount);
+            result.Z = MathUtil.Lerp(start.Z, end.Z, amount);
+            result.W = MathUtil.Lerp(start.W, end.W, amount);
         }
 
         /// <summary>
@@ -647,8 +645,6 @@ namespace SharpDX
         /// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
         /// <returns>The linear interpolation of the two vectors.</returns>
         /// <remarks>
-        /// This method performs the linear interpolation based on the following formula.
-        /// <code>start + (end - start) * amount</code>
         /// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned. 
         /// </remarks>
         public static Vector4 Lerp(Vector4 start, Vector4 end, float amount)
@@ -670,10 +666,7 @@ namespace SharpDX
             amount = (amount > 1.0f) ? 1.0f : ((amount < 0.0f) ? 0.0f : amount);
             amount = (amount * amount) * (3.0f - (2.0f * amount));
 
-            result.X = start.X + ((end.X - start.X) * amount);
-            result.Y = start.Y + ((end.Y - start.Y) * amount);
-            result.Z = start.Z + ((end.Z - start.Z) * amount);
-            result.W = start.W + ((end.W - start.W) * amount);
+            Lerp(ref start, ref end, amount, out result);
         }
 
         /// <summary>


### PR DESCRIPTION
Each class implements lerp just once and they all use MathUtil.Lerp().
