### PR TITLE
[SharpDX] Add cast operators to Rectangle/F

### DIFF
--- a/Source/SharpDX/Rectangle.cs
+++ b/Source/SharpDX/Rectangle.cs
@@ -25,9 +25,9 @@ using SharpDX.Serialization;
 namespace SharpDX
 {
     /// <summary>
-    /// Define a Rectangle. This structure is slightly different from System.Drawing.Rectangle as It is 
+    /// Define a Rectangle. This structure is slightly different from System.Drawing.Rectangle as it is 
     /// internally storing Left,Top,Right,Bottom instead of Left,Top,Width,Height.
-    /// Although automatic casting from a to System.Drawing.Rectangle is provided by this class.
+    /// Explicit casting to/from a System.Drawing.Rectangle is provided by this class.
     /// </summary>
 #if !W8CORE
     [Serializable]
@@ -475,6 +475,26 @@ namespace SharpDX
         public static bool operator !=(Rectangle left, Rectangle right)
         {
             return !(left == right);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="SharpDX.Rectangle"/> to <see cref="System.Drawing.Rectangle"/>.
+        /// </summary>
+        /// <param name="rectangle">The SharpDX.Rectangle.</param>
+        /// <returns>The System.Drawing.Rectangle.</returns>
+        public static explicit operator System.Drawing.Rectangle(Rectangle rectangle)
+        {
+            return new System.Drawing.Rectangle(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="System.Drawing.Rectangle"/> to <see cref="SharpDX.Rectangle"/>.
+        /// </summary>
+        /// <param name="rectangle">The System.Drawing.Rectangle.</param>
+        /// <returns>The SharpDX.Rectangle.</returns>
+        public static explicit operator Rectangle(System.Drawing.Rectangle rectangle)
+        {
+            return new Rectangle(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
         }
 
         internal void MakeXYAndWidthHeight()

--- a/Source/SharpDX/RectangleF.cs
+++ b/Source/SharpDX/RectangleF.cs
@@ -25,9 +25,9 @@ using SharpDX.Serialization;
 namespace SharpDX
 {
     /// <summary>
-    /// Define a RectangleF. This structure is slightly different from System.Drawing.RectangleF as It is 
+    /// Define a RectangleF. This structure is slightly different from System.Drawing.RectangleF as it is 
     /// internally storing Left,Top,Right,Bottom instead of Left,Top,Width,Height.
-    /// Although automatic casting from a to System.Drawing.Rectangle is provided by this class.
+    /// Explicit casting to/from a System.Drawing.RectangleF is provided by this class.
     /// </summary>
 #if !W8CORE
     [Serializable]
@@ -471,6 +471,26 @@ namespace SharpDX
         public static bool operator !=(RectangleF left, RectangleF right)
         {
             return !(left == right);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="SharpDX.RectangleF"/> to <see cref="System.Drawing.RectangleF"/>.
+        /// </summary>
+        /// <param name="rectangle">The SharpDX.RectangleF.</param>
+        /// <returns>The System.Drawing.RectangleF.</returns>
+        public static explicit operator System.Drawing.RectangleF(RectangleF rectangle)
+        {
+            return new System.Drawing.RectangleF(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
+        }
+
+        /// <summary>
+        /// Performs an explicit conversion from <see cref="System.Drawing.RectangleF"/> to <see cref="SharpDX.RectangleF"/>.
+        /// </summary>
+        /// <param name="rectangle">The System.Drawing.RectangleF.</param>
+        /// <returns>The SharpDX.RectangleF.</returns>
+        public static explicit operator RectangleF(System.Drawing.RectangleF rectangle)
+        {
+            return new RectangleF(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Comments at the top of the files stated that implicit cast operators
were provided, but they were not. These new cast operators are
explicit which will hopefully discourage overuse of casting. If
nothing else, at least it will be obvious when a cast occurs.
