### PR TITLE
SharpDXElement Game should be XAML-defined and inheritable

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.Game/Desktop/GameWindowDesktopWpf.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Game/Desktop/GameWindowDesktopWpf.cs
@@ -133,9 +133,12 @@ namespace SharpDX.Toolkit
         internal override void Initialize(GameContext gameContext)
         {
             if (gameContext == null) throw new ArgumentNullException("gameContext");
-
-            element = gameContext.Control as SharpDXElement;
-            if (element == null) throw new ArgumentException("Only SharpDXElement is supported at this time", "gameContext");
+						/* imho
+						 * element = gameContext.Control as SharpDXElement;
+						 * isn't that good. Checking if gameContext.Control is assignable from SharpDXElement is better. */
+						if (gameContext.Control.GetType().IsAssignableFrom(typeof(SharpDXElement)))
+							element = (SharpDXElement)gameContext.Control; // may be an Operator for SharpDXElement can be used here.
+            if (element == null) throw new ArgumentException("Only SharpDXElement is supported at this time", "gameContext"); // modify exception message
 
             var width = gameContext.RequestedWidth;
             if (width <= 0)

--- a/Source/Toolkit/SharpDX.Toolkit.Game/Desktop/SharpDXElement.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Game/Desktop/SharpDXElement.cs
@@ -30,8 +30,9 @@ namespace SharpDX.Toolkit
     /// <summary>
     /// An framework element that supports rendering D3D11 scene.
     /// </summary>
-    public sealed class SharpDXElement : FrameworkElement, IDisposable
+    public class SharpDXElement : FrameworkElement, IDisposable // removed sealed
     {
+			//does it have to be sealed? If I want to have another implementation of this in my own program this won't work!
         private readonly D3DImage image;
         private readonly Direct3DEx direct3D;
         private readonly DeviceEx device9;
@@ -61,6 +62,9 @@ namespace SharpDX.Toolkit
         /// </summary>
         public static readonly DependencyProperty SendResizeDelayProperty = DependencyProperty
             .Register("SendResizeDelay", typeof(TimeSpan), typeof(SharpDXElement), new FrameworkPropertyMetadata(TimeSpan.FromSeconds(1), HandleResizeDelayChanged));
+
+				public static readonly DependencyProperty GameProperty = DependencyProperty
+					.Register("Game", typeof(Game), typeof(SharpDXElement), new PropertyMetadata(default(Game)));
 
         /// <summary>
         /// Indicates whether the rendering should be done in the <see cref="System.Windows.Threading.DispatcherPriority.Input"/> priority.
@@ -162,6 +166,24 @@ namespace SharpDX.Toolkit
             get { return (bool)GetValue(LowPriorityRenderingProperty); }
             set { SetValue(LowPriorityRenderingProperty, value); }
         }
+
+				public Game Game {
+					get {
+						return (Game)GetValue(GameProperty);
+					}
+					set {
+						SetValue(GameProperty, value);
+
+						if (Game != null && !Game.IsRunning)
+							Game.Run(this);
+					}
+				}
+
+			//fallback if above does not work!
+				public void Run() {
+					if (Game != null)
+						Game.Run(this);
+				}
 
         /// <summary>
         /// Converts an <see cref="SharpDXElement"/> to <see cref="GameContext"/>.


### PR DESCRIPTION
I changed `SharpDXElement.cs` to fit inheritance and usage of XAML binding.
One may use `<SharpDXElement Game="AnyGameObject" />` now but I couldn't test it. It might ne wrong.
If it is not I would appreciate it if you implement this because I have to use it while I can't compile it.
Changed some things in GameWindowDesktopWpf aswell.
