### PR TITLE
XInput.Controller.GetCapabilities() Overload

### DIFF
--- a/Source/SharpDX.XInput/Controller.cs
+++ b/Source/SharpDX.XInput/Controller.cs
@@ -73,6 +73,17 @@ namespace SharpDX.XInput
         }
 
         /// <summary>
+        /// Gets the capabilities.
+        /// </summary>
+        /// <param name="deviceQueryType">Type of the device query.</param>
+        /// <param name="capabilities">The capabilities of this controller.</param>
+        /// <returns><c>true</c> if the controller is connected, <c>false</c> otherwise.</returns>
+        public bool GetCapabilities(DeviceQueryType deviceQueryType, out Capabilities capabilities)
+        {
+            return XInput.XInputGetCapabilities((int)userIndex, deviceQueryType, out capabilities) == 0;
+        }
+
+        /// <summary>
         /// Gets the keystroke.
         /// </summary>
         /// <param name="deviceQueryType">The flag.</param>


### PR DESCRIPTION
I added a simple new overload to `XInput.Controller.GetCapabilities()` which matches a similar overload for `Controller.GetState()`.  

Currently you have to do this:

```
if (!myController.IsConnected)
{
   // The device is disconnected!
   return false;
}

var capabilities = myController.GetCapabilities(DeviceQueryType.Any);
```

In this code `IsConnected` under the hood calls `XInput.XInputGetState` to test for a device connection, so this code uses 2 Pinvokes to function.  That however is redundant as `XInput.XInputGetCapabilities` also supports detection of disconnected state via the same `ERROR_DEVICE_NOT_CONNECTED` return value.

So this new overload allows you to make a single call like so:

```
Capabilities capabilities;
if (!myController.GetCapabilities(DeviceQueryType.Any, out capabilities))
{
   // The device is disconnected!
   return false;
}
```

This only uses one PInvoke to XInput.
