### PR TITLE
Fixes double byte character GetCharABCWidthFloat returns null

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.Compiler/Font/TrueTypeImporter.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Compiler/Font/TrueTypeImporter.cs
@@ -241,7 +241,7 @@ namespace SharpDX.Toolkit.Graphics
                         // Query the character spacing.
                         var result = new NativeMethods.ABCFloat[1];
 
-                        if (NativeMethods.GetCharABCWidthsFloat(hdc, character, character, result))
+                        if (NativeMethods.GetCharABCWidthsFloatW(hdc, character, character, result))
                         {
                             return result[0].A + 
                                    result[0].B + 
@@ -279,7 +279,7 @@ namespace SharpDX.Toolkit.Graphics
             public static extern bool DeleteObject(IntPtr hObject);
 
             [DllImport("gdi32.dll")]
-            public static extern bool GetCharABCWidthsFloat(IntPtr hdc, uint iFirstChar, uint iLastChar, [Out] ABCFloat[] lpABCF);
+            public static extern bool GetCharABCWidthsFloatW(IntPtr hdc, uint iFirstChar, uint iLastChar, [Out] ABCFloat[] lpABCF);
 
 
             [StructLayout(LayoutKind.Sequential)]


### PR DESCRIPTION
I've tried to use russian characters (>1000 character region) - and realized GetCharABCWidthsFloat doesn't work for it, which results in terrible text rendered. Quick search - found only this http://forums.codeguru.com/showthread.php?367916-Get-character-width. Strangely (or maybe it makes sense), Unicode version of this function fixes it.
