### PR TITLE
Fixed NullReferenceException while converting CompilationResult to ShaderBytecode

### DIFF
--- a/Source/SharpDX.D3DCompiler/CompilationResult.cs
+++ b/Source/SharpDX.D3DCompiler/CompilationResult.cs
@@ -45,7 +45,7 @@ namespace SharpDX.D3DCompiler
         /// </returns>
         public static implicit operator ShaderBytecode(CompilationResult input)
         {
-            return input.Bytecode;
+            return (input != null) ? input.Bytecode : null;
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace SharpDX.D3DCompiler
         /// </returns>
         public static implicit operator byte[](CompilationResult input)
         {
-            return input.Bytecode;
+            return (input != null) ? input.Bytecode : null;
         }
     }
 }

--- a/Source/SharpDX.Direct3D9/CompilationResult.cs
+++ b/Source/SharpDX.Direct3D9/CompilationResult.cs
@@ -45,10 +45,7 @@ namespace SharpDX.Direct3D9
         /// </returns>
         public static implicit operator ShaderBytecode(CompilationResult input)
         {
-            if ((object)input == null)
-                return null;
-                
-            return input.Bytecode;
+            return (input != null) ? input.Bytecode : null;
         }
     }
 }


### PR DESCRIPTION
Previously the implicit conversion operator threw a NullReferenceException because no null check was performed.

When checking for null, compiling a shader directly inside a using clause and returning null if no entry point is given, is possible.

e.g.

```
using (ShaderBytecode shaderByteCode = (!String.IsNullOrEmpty(shaderEntryPoint)) ?
                                                    ShaderBytecode.Compile(uncompiledShaderBytes, shaderEntryPoint, shaderProfile) :
                                                    null)
{
    // ...
}
```
