### PR TITLE
Fix https://github.com/sharpdx/SharpDX/issues/236

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.Graphics/SpriteFont.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Graphics/SpriteFont.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2010-2013 SharpDX - Alexandre Mutel
+// Copyright (c) 2010-2013 SharpDX - Alexandre Mutel
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -394,14 +394,14 @@ namespace SharpDX.Toolkit.Graphics
 
                             var glyph = (SpriteFontData.Glyph*) pGlyph + glyphIndex;
 
-                            // do not offset the first character, otherwise it is impossible to compute correct alignment
-                            // using MeasureString results
-                            if (x > 0f) x += glyph->Offset.X;
+                            // Do not offset the first character, otherwise it is impossible to compute correct alignment.
+                            // Also handles white space if it is the first character.
+                            if (i != 0 || char.IsWhiteSpace(character))
+                            {
+                                x += glyph->Offset.X;
+                            }
 
-                            // reset negative offset (it can happen only for first character)
-                            if(x < 0f) x = 0f;
-
-                            // Offset the kerning
+                            // Offset the kerning, except for the first character
                             float kerningOffset;
                             if (kerningMap != null && kerningMap.TryGetValue(key, out kerningOffset))
                                 x += kerningOffset;


### PR DESCRIPTION
Instead of checking (x > 0f) it instead uses the index to determine whether this is the first character.

With 1 pixel width letters before there was no offset addition to the X at

x += glyph->XAdvance + Spacing;

meaning the next iteration will still think it is the first character since X still would have been 0.

The only drawback is that issue https://github.com/sharpdx/SharpDX/issues/86 is back but only if the whitespace is the first character (I cant think of any logical reason as to why someone would have a whitespace first).

Mostly trial and error since I had no knowledge of glyphs/etc... before this.

If the whitespace drawback results in this not being accepted I am sure I could figure out how to overcome it.
