### PR TITLE
Two more properties on EffectPass and FunctionLinkingGraph

### DIFF
--- a/Source/SharpDX.D3DCompiler/FunctionLinkingGraph.cs
+++ b/Source/SharpDX.D3DCompiler/FunctionLinkingGraph.cs
@@ -104,6 +104,15 @@ namespace SharpDX.D3DCompiler
             return module;
         }
 
+        /// <summary>
+        /// Gets the error from the last function call of the function-linking-graph, as a string
+        /// </summary>
+        public string LastErrorString
+        {
+            get { return Utilities.BlobToString(this.LastError);  }
+        }
+
+
         /// <summary>	
         /// <p>[This documentation is preliminary and is subject to change.]</p><p>Creates a call-function linking node to use in the function-linking-graph.</p>	
         /// </summary>	

--- a/Source/SharpDX.Direct3D11.Effects/EffectPassDescription.cs
+++ b/Source/SharpDX.Direct3D11.Effects/EffectPassDescription.cs
@@ -34,6 +34,14 @@ namespace SharpDX.Direct3D11
                 return new ShaderBytecode(this.PIAInputSignature, this.IAInputSignatureSize);
             }
         }
+
+        /// <summary>
+        /// Returns true if this Effect pass has a Signature (eg: if a VertexShader or Geometry Shader is present), false otherwise
+        /// </summary>
+        public bool HasSignature
+        {
+            get { return this.PIAInputSignature != System.IntPtr.Zero; }
+        }
     }
 }
 #endif


### PR DESCRIPTION
Hello,

Added HasSignature Property on EffectPassDescription (since we haven't got access to the internal pointer, so it saves time reflecting if there is vertex/geometry shader).

Added LastErrorString property on function linking graph (as most times we'll want to access Error directly as string).

Thanks
