### PR TITLE
map to the correct DLL for MFCreateSinkWriterFromURL (Mfreadwrite.dll)

### DIFF
--- a/Source/SharpDX.MediaFoundation/Mapping-core.xml
+++ b/Source/SharpDX.MediaFoundation/Mapping-core.xml
@@ -872,6 +872,7 @@
     <map function="Create.*" dll='"Temp.dll"' group="SharpDX.MediaFoundation.MediaFactory"/>
 
     <map function="MFCreateSourceReader.*" dll='"Mfreadwrite.dll"'/>
+    <map function="MFCreateSinkWriterFromURL.*" dll='"Mfreadwrite.dll"'/>
 
     <map function="MFCreateWaveFormatExFromMFMediaType" visibility="internal"/>
     <map param="MFCreateWaveFormatExFromMFMediaType::ppWF" type="void"/>


### PR DESCRIPTION
small bugfix to get MediaFoundation encoding working using the MFCreateSinkWriterFromURL function
