### PR TITLE
Exposes Boolean for D3D rendering in DesignMode as DependencyProperty

### DIFF
--- a/Samples/Win81/MiniCubeXaml/Direct3DUserControl.xaml.cs
+++ b/Samples/Win81/MiniCubeXaml/Direct3DUserControl.xaml.cs
@@ -46,11 +46,15 @@ namespace MiniCubeXaml
         public Direct3DUserControl()
         {
             this.InitializeComponent();
+            // Do D3D initialization when element is loaded, because DesignModeD3DRendering is yet not set in ctor
+            this.Loaded += Direct3DUserControl_Loaded;            
+        }
 
-            // do not initialize D3D in design mode as it may cause designer crashes
-            if(Windows.ApplicationModel.DesignMode.DesignModeEnabled)
-                if (!DesignModeD3DRendering)
-                    return;
+        void Direct3DUserControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            // Do not initialize D3D in design mode as default, since it may cause designer crashes
+            if (Windows.ApplicationModel.DesignMode.DesignModeEnabled && !DesignModeD3DRendering)
+                return;
 
             // Safely dispose any previous instance
             // Creates a new DeviceManager (Direct3D, Direct2D, DirectWrite, WIC)


### PR DESCRIPTION
So one can switch rendering in VS-Desingner or Blend. This is usefull as D3D rendering by itself in DesignMode was not cause of the failure and makes sense in most cases. But CubeRenderer, and propably some other bad D3D would cause the Designer to crash. In case you dont have bad D3D, one can still enable rendering if needed.
