### PR TITLE
Added space efficent Project/Unproject Overloads

### DIFF
--- a/Source/SharpDX/Vector3.cs
+++ b/Source/SharpDX/Vector3.cs
@@ -1282,6 +1282,18 @@ namespace SharpDX
             return result;
         }
 
+        /// <summary>
+        /// Transforms a 3D vector by the given <see cref="SharpDX.Matrix"/>.
+        /// </summary>
+        /// <param name="vector">The source vector.</param>
+        /// <param name="transform">The transformation <see cref="SharpDX.Matrix"/>.</param>
+        /// <param name="result">When the method completes, contains the transformed <see cref="SharpDX.Vector3"/>.</param>
+        public static void Transform(ref Vector3 vector, ref Matrix transform, out Vector3 result)
+        {
+            Vector4 intermediate;
+            Transform(ref vector, ref transform, out intermediate);
+            result = (Vector3)intermediate;
+        }
 
         /// <summary>
         /// Transforms a 3D vector by the given <see cref="SharpDX.Matrix"/>.

--- a/Source/SharpDX/Viewport.cs
+++ b/Source/SharpDX/Viewport.cs
@@ -218,11 +218,27 @@ namespace SharpDX
         /// <param name="projection">The projection matrix.</param>
         /// <param name="view">The view matrix.</param>
         /// <param name="world">The world matrix.</param>
-        /// <returns>Vector3.</returns>
+        /// <returns>The projected vector./returns>
         public Vector3 Project(Vector3 source, Matrix projection, Matrix view, Matrix world)
         {
-            var matrix = Matrix.Multiply(Matrix.Multiply(world, view), projection);
-            var vector = (Vector3)Vector3.Transform(source, matrix);
+            Matrix matrix;
+            Matrix.Multiply(ref world, ref view, out matrix);
+            Matrix.Multiply(ref matrix, ref projection, out matrix);
+
+            Vector3 vector;
+            Project(ref source, ref matrix, out vector);
+            return vector;
+        }
+
+        /// <summary>
+        /// Projects a 3D vector from object space into screen space.
+        /// </summary>
+        /// <param name="source">The vector to project.</param>
+        /// <param name="matrix">A combined WorldViewProjection matrix.</param>
+        /// <param name="vector">The projected vector.</param>
+        public void Project(ref Vector3 source, ref Matrix matrix, out Vector3 vector)
+        {
+            Vector3.Transform(ref source, ref matrix, out vector);
             float a = (((source.X * matrix.M14) + (source.Y * matrix.M24)) + (source.Z * matrix.M34)) + matrix.M44;
 
             if (!MathUtil.IsOne(a))
@@ -233,8 +249,6 @@ namespace SharpDX
             vector.X = (((vector.X + 1f) * 0.5f) * Width) + X;
             vector.Y = (((-vector.Y + 1f) * 0.5f) * Height) + Y;
             vector.Z = (vector.Z * (MaxDepth - MinDepth)) + MinDepth;
-
-            return vector;
         }
 
         /// <summary>
@@ -244,22 +258,38 @@ namespace SharpDX
         /// <param name="projection">The projection matrix.</param>
         /// <param name="view">The view matrix.</param>
         /// <param name="world">The world matrix.</param>
-        /// <returns>Vector3.</returns>
+        /// <returns>The unprojected Vector.</returns>
         public Vector3 Unproject(Vector3 source, Matrix projection, Matrix view, Matrix world)
         {
-            var matrix = Matrix.Invert(Matrix.Multiply(Matrix.Multiply(world, view), projection));
-            source.X = (((source.X - X) / (Width)) * 2f) - 1f;
-            source.Y = -((((source.Y - Y) / (Height)) * 2f) - 1f);
-            source.Z = (source.Z - MinDepth) / (MaxDepth - MinDepth);
-            var vector = (Vector3)Vector3.Transform(source, matrix);
+            Matrix matrix;
+            Matrix.Multiply(ref world, ref view, out matrix);
+            Matrix.Multiply(ref matrix, ref projection, out matrix);
+            Matrix.Invert(ref matrix, out matrix);
 
-            float a = (((source.X * matrix.M14) + (source.Y * matrix.M24)) + (source.Z * matrix.M34)) + matrix.M44;
+            Vector3 vector;
+            Unproject(ref source, ref matrix, out vector);
+            return vector;
+        }
+
+        /// <summary>
+        /// Converts a screen space point into a corresponding point in world space.
+        /// </summary>
+        /// <param name="source">The vector to project.</param>
+        /// <param name="matrix">An inverted combined WorldViewProjection matrix.</param>
+        /// <param name="vector">The unprojected vector.</param>
+        public void Unproject(ref Vector3 source, ref Matrix matrix, out Vector3 vector)
+        {
+            vector.X = (((source.X - X) / (Width)) * 2f) - 1f;
+            vector.Y = -((((source.Y - Y) / (Height)) * 2f) - 1f);
+            vector.Z = (source.Z - MinDepth) / (MaxDepth - MinDepth);
+
+            float a = (((vector.X * matrix.M14) + (vector.Y * matrix.M24)) + (vector.Z * matrix.M34)) + matrix.M44;
+            Vector3.Transform(ref vector, ref matrix, out vector);
+
             if (!MathUtil.IsOne(a))
             {
                 vector = (vector / a);
             }
-
-            return vector;
         }
 
         /// <summary>

--- a/Source/SharpDX/ViewportF.cs
+++ b/Source/SharpDX/ViewportF.cs
@@ -219,11 +219,27 @@ namespace SharpDX
         /// <param name="projection">The projection matrix.</param>
         /// <param name="view">The view matrix.</param>
         /// <param name="world">The world matrix.</param>
-        /// <returns>Vector3.</returns>
+        /// <returns>The projected vector./returns>
         public Vector3 Project(Vector3 source, Matrix projection, Matrix view, Matrix world)
         {
-            var matrix = Matrix.Multiply(Matrix.Multiply(world, view), projection);
-            var vector = (Vector3)Vector3.Transform(source, matrix);
+            Matrix matrix;
+            Matrix.Multiply(ref world, ref view, out matrix);
+            Matrix.Multiply(ref matrix, ref projection, out matrix);
+
+            Vector3 vector;
+            Project(ref source, ref matrix, out vector);
+            return vector;
+        }
+
+        /// <summary>
+        /// Projects a 3D vector from object space into screen space.
+        /// </summary>
+        /// <param name="source">The vector to project.</param>
+        /// <param name="matrix">A combined WorldViewProjection matrix.</param>
+        /// <param name="vector">The projected vector.</param>
+        public void Project(ref Vector3 source, ref Matrix matrix, out Vector3 vector)
+        {
+            Vector3.Transform(ref source, ref matrix, out vector);
             float a = (((source.X * matrix.M14) + (source.Y * matrix.M24)) + (source.Z * matrix.M34)) + matrix.M44;
 
             if (!MathUtil.IsOne(a))
@@ -234,8 +250,6 @@ namespace SharpDX
             vector.X = (((vector.X + 1f) * 0.5f) * Width) + X;
             vector.Y = (((-vector.Y + 1f) * 0.5f) * Height) + Y;
             vector.Z = (vector.Z * (MaxDepth - MinDepth)) + MinDepth;
-
-            return vector;
         }
 
         /// <summary>
@@ -245,22 +259,38 @@ namespace SharpDX
         /// <param name="projection">The projection matrix.</param>
         /// <param name="view">The view matrix.</param>
         /// <param name="world">The world matrix.</param>
-        /// <returns>Vector3.</returns>
+        /// <returns>The unprojected Vector.</returns>
         public Vector3 Unproject(Vector3 source, Matrix projection, Matrix view, Matrix world)
         {
-            var matrix = Matrix.Invert(Matrix.Multiply(Matrix.Multiply(world, view), projection));
-            source.X = (((source.X - X) / (Width)) * 2f) - 1f;
-            source.Y = -((((source.Y - Y) / (Height)) * 2f) - 1f);
-            source.Z = (source.Z - MinDepth) / (MaxDepth - MinDepth);
-            var vector = (Vector3)Vector3.Transform(source, matrix);
+            Matrix matrix;
+            Matrix.Multiply(ref world, ref view, out matrix);
+            Matrix.Multiply(ref matrix, ref projection, out matrix);
+            Matrix.Invert(ref matrix, out matrix);
 
-            float a = (((source.X * matrix.M14) + (source.Y * matrix.M24)) + (source.Z * matrix.M34)) + matrix.M44;
+            Vector3 vector;
+            Unproject(ref source, ref matrix, out vector);
+            return vector;
+        }
+
+        /// <summary>
+        /// Converts a screen space point into a corresponding point in world space.
+        /// </summary>
+        /// <param name="source">The vector to project.</param>
+        /// <param name="matrix">An inverted combined WorldViewProjection matrix.</param>
+        /// <param name="vector">The unprojected vector.</param>
+        public void Unproject(ref Vector3 source, ref Matrix matrix, out Vector3 vector)
+        {
+            vector.X = (((source.X - X) / (Width)) * 2f) - 1f;
+            vector.Y = -((((source.Y - Y) / (Height)) * 2f) - 1f);
+            vector.Z = (source.Z - MinDepth) / (MaxDepth - MinDepth);
+
+            float a = (((vector.X * matrix.M14) + (vector.Y * matrix.M24)) + (vector.Z * matrix.M34)) + matrix.M44;
+            Vector3.Transform(ref vector, ref matrix, out vector);
+
             if (!MathUtil.IsOne(a))
             {
                 vector = (vector / a);
             }
-
-            return vector;
         }
 
         /// <summary>


### PR DESCRIPTION
If you use Viewport.Project & Viewport.Unproject a lot, you end up spending a lot of time copying matrices.  This reduces that load by exposing by exposing new method signatures that are similar to the static Matrix methods.
