### PR TITLE
If count exceeds SoundStream data range, only read to data range end

### DIFF
--- a/Source/SharpDX/Multimedia/SoundStream.cs
+++ b/Source/SharpDX/Multimedia/SoundStream.cs
@@ -356,7 +356,7 @@ namespace SharpDX.Multimedia
         ///   </exception>
         public override int Read(byte[] buffer, int offset, int count)
         {
-            return input.Read(buffer, offset, Math.Min(count, (int)(startPositionOfData + length - input.Position)));
+            return input.Read(buffer, offset, Math.Min(count, (int)Math.Max(startPositionOfData + length - input.Position, 0)));
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request is associated with Issue #312.

I have also prepared a few unit tests, where I have added a WAV file to the unit test project to verify the correctness of the fix. If you want me to, I can include the unit test commit in this pull request, otherwise I'll wait for you to accept or reject this request until I upload anything else to my fork.

Best regards,
Anders @ Cureos
