### PR TITLE
[Toolkit.Audio] SoundEffectInstance can now be returned to the pool

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.Audio/SoundEffectInstance.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Audio/SoundEffectInstance.cs
@@ -573,5 +573,15 @@ namespace SharpDX.Toolkit.Audio
 
             voice.SetOutputMatrix(sourceChannels, destinationChannels, outputMatrix);
         }
+
+        /// <summary>
+        /// Returns this SoundEffectInstance to the SoundEffect InstancePool.
+        /// You should not continue to call other functions on this object.
+        /// </summary>
+        public void Return()
+        {
+            ReleaseSourceVoice();
+            Effect.AudioManager.InstancePool.Return(this);
+        }
     }
 }

--- a/Source/Toolkit/SharpDX.Toolkit.Audio/SoundEffectInstancePool.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Audio/SoundEffectInstancePool.cs
@@ -130,6 +130,15 @@ namespace SharpDX.Toolkit.Audio
             }
         }
 
+        /// <summary>
+        /// Returns the speicfied SoundEffectInstance to the instance pool
+        /// </summary>
+        /// <param name="item">SFXInstance to return to instance pool</param>
+        internal void Return(SoundEffectInstance item)
+        {
+            instancePool.Return(item);
+        }
+
         private void Dispose(bool disposing)
         {
             if (!IsDisposed)


### PR DESCRIPTION
I just added a bit of functionality so that I could return my SoundEffectInstance objects to the pool of available instances when I was done with it.
