### PR TITLE
Fix dll import for CoCreateInstanceApp 

### DIFF
--- a/Source/SharpDX/Utilities.cs
+++ b/Source/SharpDX/Utilities.cs
@@ -1323,7 +1323,15 @@ namespace SharpDX
             comObject.NativePointer = localQuery.IUnknownPointer;
         }
 #else
-        // TODO THIS IS NOT TESTED under W8CORE
+        #if W8CORE
+        [DllImport("Combase.dll", ExactSpelling = true, EntryPoint = "CoCreateInstanceFromApp", PreserveSig = true)]
+        private static extern Result CoCreateInstanceFromApp([In, MarshalAs(UnmanagedType.LPStruct)] Guid rclsid, 
+            IntPtr pUnkOuter, 
+            CLSCTX dwClsContext, 
+            IntPtr reserved,
+            int countMultiQuery,
+            ref MultiQueryInterface query);
+        #else
         [DllImport("ole32.dll", ExactSpelling = true, EntryPoint = "CoCreateInstanceFromApp", PreserveSig = true)]
         private static extern Result CoCreateInstanceFromApp([In, MarshalAs(UnmanagedType.LPStruct)] Guid rclsid, 
             IntPtr pUnkOuter, 
@@ -1331,6 +1339,7 @@ namespace SharpDX
             IntPtr reserved,
             int countMultiQuery,
             ref MultiQueryInterface query);
+         #endif
 
         internal unsafe static void CreateComInstance(Guid clsid, CLSCTX clsctx, Guid riid, ComObject comObject)
         {


### PR DESCRIPTION
As mentioned in previous pull request, now you have single commit instead.

According to this link : http://msdn.microsoft.com/en-us/library/windows/desktop/hh404137(v=vs.85).aspx

It says that function is available for desktop, store and phone, so certification should not be a problem (I suspect ole32.dll reference might be needed for windows 7 desktop support, but I can't test that right now).
