### PR TITLE
Exposed IndexBuffer & VertexBuffer in Geometric Primitives

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.Graphics/GeometricPrimitive.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Graphics/GeometricPrimitive.cs
@@ -31,12 +31,12 @@ namespace SharpDX.Toolkit.Graphics
         /// <summary>
         /// The index buffer used by this geometric primitive.
         /// </summary>
-        private readonly Buffer indexBuffer;
+        public Buffer IndexBuffer { get; private set; }
 
         /// <summary>
         /// The vertex buffer used by this geometric primitive.
         /// </summary>
-        private readonly Buffer<T> vertexBuffer;
+        public Buffer<T> VertexBuffer { get; private set; }
 
         /// <summary>
         /// The default graphics device.
@@ -51,7 +51,7 @@ namespace SharpDX.Toolkit.Graphics
         /// <summary>
         /// True if the index buffer is a 32 bit index buffer.
         /// </summary>
-        private readonly bool isIndex32Bits;
+        public bool IsIndex32Bits { get; private set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GeometricPrimitive" /> class.
@@ -73,8 +73,8 @@ namespace SharpDX.Toolkit.Graphics
             if (toLeftHanded)
                 ReverseWinding(vertices, indices);
 
-            indexBuffer = ToDispose(Buffer.Index.New(graphicsDevice, indices));
-            vertexBuffer = ToDispose(Buffer.Vertex.New(graphicsDevice, vertices));
+            IndexBuffer = ToDispose(Buffer.Index.New(graphicsDevice, indices));
+            VertexBuffer = ToDispose(Buffer.Vertex.New(graphicsDevice, vertices));
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace SharpDX.Toolkit.Graphics
                 {
                     indicesShort[i] = (ushort)indices[i];
                 }
-                indexBuffer = ToDispose(Buffer.Index.New(graphicsDevice, indicesShort));
+                IndexBuffer = ToDispose(Buffer.Index.New(graphicsDevice, indicesShort));
             }
             else
             {
@@ -108,11 +108,11 @@ namespace SharpDX.Toolkit.Graphics
                     throw new InvalidOperationException("Cannot generate more than 65535 indices on feature level HW <= 9.3");
                 }
 
-                indexBuffer = ToDispose(Buffer.Index.New(graphicsDevice, indices));
-                isIndex32Bits = true;
+                IndexBuffer = ToDispose(Buffer.Index.New(graphicsDevice, indices));
+                IsIndex32Bits = true;
             }
 
-            vertexBuffer = ToDispose(Buffer.Vertex.New(graphicsDevice, vertices));
+            VertexBuffer = ToDispose(Buffer.Vertex.New(graphicsDevice, vertices));
         }
 
         /// <summary>
@@ -181,16 +181,16 @@ namespace SharpDX.Toolkit.Graphics
                 pass.Apply();
 
             // Setup the Vertex Buffer
-            graphicsDevice.SetVertexBuffer(0, vertexBuffer);
+            graphicsDevice.SetVertexBuffer(0, VertexBuffer);
 
             // Setup the Vertex Buffer Input layout
             graphicsDevice.SetVertexInputLayout(InputLayout);
 
             // Setup the index Buffer
-            graphicsDevice.SetIndexBuffer(indexBuffer, isIndex32Bits);
+            graphicsDevice.SetIndexBuffer(IndexBuffer, IsIndex32Bits);
 
             // Finally Draw this mesh
-            graphicsDevice.DrawIndexed(primitiveType, indexBuffer.ElementCount);
+            graphicsDevice.DrawIndexed(primitiveType, IndexBuffer.ElementCount);
         }
 
         /// <summary>


### PR DESCRIPTION
I've exposed the IndexBuffer & VertexBuffer used in rendering Geometric Primitives.  This can be useful if you'd like to use the GeometricPrimitive generation code, but use a custom draw function.
