### PR TITLE
Fixed GeoSphere's texture mapping issues

### DIFF
--- a/Source/Toolkit/SharpDX.Toolkit.Graphics/GeometricPrimitive.GeoSphere.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Graphics/GeometricPrimitive.GeoSphere.cs
@@ -298,10 +298,12 @@ namespace SharpDX.Toolkit.Graphics
                                 else if (*triIndex1 == i)
                                 {
                                     Utilities.Swap(ref *triIndex0, ref *triIndex1);
+                                    Utilities.Swap(ref *triIndex1, ref *triIndex2);
                                 }
                                 else if (*triIndex2 == i)
                                 {
                                     Utilities.Swap(ref *triIndex0, ref *triIndex2);
+                                    Utilities.Swap(ref *triIndex1, ref *triIndex2);
                                 }
                                 else
                                 {
@@ -327,7 +329,7 @@ namespace SharpDX.Toolkit.Graphics
                     indices = (int*)0;
                 }
 
-                return new GeometricPrimitive(graphicsDevice, vertices.ToArray(), indexList.ToArray(), toLeftHanded) { Name = "GeoSphere"};
+                return new GeometricPrimitive(graphicsDevice, vertices.ToArray(), indicesArray, toLeftHanded) { Name = "GeoSphere"};
             }
 
             private unsafe void FixPole(int poleIndex)


### PR DESCRIPTION
Some triangles were not being rendered correctly: two more indices
needed to be swapped around. Also I updated the reference to the correct
indices array to be passed to the GeometricPrimitive constructor.

The GeoSphere appears to render correctly now, also with different tessellation values.
