### PR TITLE
Adding MFCreateSinkWriterFromMediaSink and MFCreateSinkWriterFromURL bac...

### DIFF
--- a/Source/SharpDX.MediaFoundation/Mapping-core.xml
+++ b/Source/SharpDX.MediaFoundation/Mapping-core.xml
@@ -862,8 +862,6 @@
     <ifdef name="W8CORE">
       <remove function="MFCreateAggregateSource"/>
       <remove function="MFCreateProtectedEnvironmentAccess"/>
-      <remove function="MFCreateSinkWriterFromMediaSink"/>
-      <remove function="MFCreateSinkWriterFromURL"/>
       <remove function="MFGetLocalId"/>
       <remove function="MFGetService"/>
       <remove function="MFGetSystemId"/>


### PR DESCRIPTION
...k to W8CORE.

MFCreateSinkWriterFromMediaSink is supported from Vista all the way to Windows store apps, and Windows Phone 8.1:
http://msdn.microsoft.com/en-us/library/windows/desktop/dd388103(v=vs.85).aspx

I have been working with MFCreateSinkWriterFromMediaSink on an app that I've been testing with Windows 8.1 on an Intel chip, and on a Surface RT.

MFCreateSinkWriterFromURL is supported from Vista all the way to Windows store apps, and Windows Phone 8.1:
http://msdn.microsoft.com/en-us/library/windows/desktop/dd388105(v=vs.85).aspx
