### PR TITLE
[MediaFoundation] SourceReader.GetCurrentMediaType passes index through ...

### DIFF
--- a/Source/SharpDX.MediaFoundation/SourceReader.cs
+++ b/Source/SharpDX.MediaFoundation/SourceReader.cs
@@ -232,7 +232,7 @@ namespace SharpDX.MediaFoundation
         /// <unmanaged-short>IMFSourceReader::GetCurrentMediaType</unmanaged-short>	
         public SharpDX.MediaFoundation.MediaType GetCurrentMediaType(SourceReaderIndex readerIndex)
         {
-            return GetCurrentMediaType((int)SourceReaderIndex.FirstAudioStream);
+            return GetCurrentMediaType((int)readerIndex);
         }
 
         /// <summary>	


### PR DESCRIPTION
When I was working with Media Foundation I was getting a weird result when I tried to pull the 'FirstVideoStream'. It turns out that it would push the 'FirstAudioStream' regardless (I had to resort to casting to an int myself). This pull request should fix that.
