### PR TITLE
[SharpDX.XAudio2]  Added UseFilter enum-item back to VoiceFlags.

### DIFF
--- a/Source/SharpDX.XAudio2/Mapping-xaudio2.xml
+++ b/Source/SharpDX.XAudio2/Mapping-xaudio2.xml
@@ -43,8 +43,7 @@
     <context>xaudio2</context>
     <context>xaudio2fx</context>
     <create-cpp enum="XAUDIO2_VOICE_SEND_FLAGS" macro="XAUDIO2_SEND_(USEFILTER)" />
-    <create-cpp enum="XAUDIO2_SUBMIX_VOICE_FLAGS" macro="XAUDIO2_VOICE_USEFILTER" />
-    <create-cpp enum="XAUDIO2_VOICE_FLAGS" macro="XAUDIO2_VOICE_[^U].*" />
+    <create-cpp enum="XAUDIO2_VOICE_FLAGS" macro="XAUDIO2_VOICE_.*" />
     <create-cpp enum="XAUDIO2_FLAGS" macro="XAUDIO2_DEBUG_ENGINE" />
     <create-cpp enum="XAUDIO2_PLAY_FLAGS" macro="XAUDIO2_PLAY_.*" />
     <create-cpp enum="XAUDIO2_LOG_TYPE" macro="XAUDIO2_LOG_.*" />
@@ -178,8 +177,6 @@
     <map enum-item="XAUDIO2_VOICE_NOSRC" name="NoSampleRateConversion"/>
     <map enum-item="XAUDIO2_VOICE_USEFILTER" name="UseFilter"/>
     <map enum-item="XAUDIO2_VOICE_MUSIC" name="Music"/>
-
-    <map enum="XAUDIO2_SUBMIX_VOICE_FLAGS" name="SubmixVoiceFlags" />
     
     <map enum-item="XAUDIO2_SEND_(USEFILTER)" name="UseFilter"/>
 
@@ -244,7 +241,6 @@
     <map param="IXAudio2::CreateSourceVoice::ppSourceVoice" attribute="out fast" />
     <map param="IXAudio2::CreateSubmixVoice::ppSubmixVoice" attribute="out fast" />
     <map param="IXAudio2::CreateSourceVoice::Flags" type="XAUDIO2_VOICE_FLAGS" />
-    <map param="IXAudio2::CreateSubmixVoice::Flags" type="XAUDIO2_SUBMIX_VOICE_FLAGS" />
     <map param="IXAudio2::CreateSourceVoice::pSourceFormat" type="void" />
     <map method="IXAudio2Voice::SetEffectChain" visibility="internal" property="false" />
     <map param="IXAudio2::SetDebugConfiguration::pDebugConfiguration" attribute="in value"/>

--- a/Source/SharpDX.XAudio2/SharpDX.XAudio2.csproj
+++ b/Source/SharpDX.XAudio2/SharpDX.XAudio2.csproj
@@ -49,6 +49,7 @@
     <Compile Include="NamespaceDoc.cs" />
     <Compile Include="SourceVoice.cs" />
     <Compile Include="SubmixVoice.cs" />
+    <Compile Include="SubmixVoiceFlags.cs" />
     <Compile Include="Voice.cs" />
     <Compile Include="VoiceShadow.cs" />
     <Compile Include="X3DAudio\DistanceCurve.cs" />

--- a/Source/SharpDX.XAudio2/SubmixVoice.cs
+++ b/Source/SharpDX.XAudio2/SubmixVoice.cs
@@ -98,13 +98,13 @@ namespace SharpDX.XAudio2
                     fixed (void* pEffectDescriptors = &effectDescriptorNatives[0])
                     {
                         tempSendDescriptor.EffectDescriptorPointer = (IntPtr)pEffectDescriptors;
-                        device.CreateSubmixVoice(this, inputChannels, inputSampleRate, flags, processingStage, null, tempSendDescriptor);
+                        device.CreateSubmixVoice(this, inputChannels, inputSampleRate, unchecked((int)flags), processingStage, null, tempSendDescriptor);
                     }
                 }
             }
             else
             {
-                device.CreateSubmixVoice(this, inputChannels, inputSampleRate, flags, processingStage, null, null);
+                device.CreateSubmixVoice(this, inputChannels, inputSampleRate, unchecked((int)flags), processingStage, null, null);
             }
         }
     }

--- a/Source/SharpDX.XAudio2/SubmixVoiceFlags.cs
+++ b/Source/SharpDX.XAudio2/SubmixVoiceFlags.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SharpDX.XAudio2
+{
+    /// <summary>	
+    /// No documentation.	
+    /// </summary>	
+    /// <include file='.\..\Documentation\CodeComments.xml' path="/comments/comment[@id='XAUDIO2_SUBMIX_VOICE_FLAGS']/*"/>
+    [Flags]
+    public enum SubmixVoiceFlags : int
+    {
+
+        /// <summary>	
+        /// No documentation.	
+        /// </summary>	
+        /// <include file='.\..\Documentation\CodeComments.xml' path="/comments/comment[@id='XAUDIO2_VOICE_USEFILTER']/*"/>	
+        /// <unmanaged>XAUDIO2_VOICE_USEFILTER</unmanaged>	
+        /// <unmanaged-short>XAUDIO2_VOICE_USEFILTER</unmanaged-short>	
+        UseFilter = VoiceFlags.UseFilter,
+
+        /// <summary>	
+        /// None.	
+        /// </summary>	
+        /// <include file='.\..\Documentation\CodeComments.xml' path="/comments/comment[@id='']/*"/>	
+        /// <unmanaged>None</unmanaged>	
+        /// <unmanaged-short>None</unmanaged-short>	
+        None = VoiceFlags.None,
+    }
+}


### PR DESCRIPTION
Hi,

This is a pull request to fix issue #453 .  I tested changes using the Toolkit.Audio.Desktop sample.

Cheers,
Dan 
