### PR TITLE
[SharpDX.Direct3D12] TextureCopyLocation alignment fix

### DIFF
--- a/Source/SharpDX.Direct3D12/CpuDescriptorHandle.cs
+++ b/Source/SharpDX.Direct3D12/CpuDescriptorHandle.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpDX.Direct3D12
+{
+    public partial struct CpuDescriptorHandle
+    {
+        /// <summary>
+        ///   Adds an offset to a descriptor handle
+        /// </summary>
+        /// <param name = "left">Initial descriptor handle</param>
+        /// <param name = "right">Offset to apply, use <see cref="SharpDX.Direct3D12.Device.GetDescriptorHandleIncrementSize(DescriptorHeapType)"/> with the relevant heap type.</param>
+        /// <returns>Offsetted descriptor handle</returns>
+        public static CpuDescriptorHandle operator +(CpuDescriptorHandle left, int right)
+        {
+            return new CpuDescriptorHandle()
+            {
+                Ptr = left.Ptr + right
+            };
+        }
+    }
+}

--- a/Source/SharpDX.Direct3D12/Device.cs
+++ b/Source/SharpDX.Direct3D12/Device.cs
@@ -255,6 +255,22 @@ namespace SharpDX.Direct3D12
                     nativeDesc.InputLayout.ElementCount = elements.Length;
                 }
 
+                //Marshal stream output elements
+                var streamOutElements = desc.StreamOutput.Elements;
+                var nativeStreamOutElements = (StreamOutputElement.__Native*)0;
+                if (streamOutElements != null && streamOutElements.Length > 0)
+                {
+                    var ptr = stackalloc StreamOutputElement.__Native[streamOutElements.Length];
+                    nativeStreamOutElements = ptr;
+                    for (int i = 0; i < streamOutElements.Length; i++)
+                    {
+                        streamOutElements[i].__MarshalTo(ref nativeStreamOutElements[i]);
+                    }
+
+                    nativeDesc.StreamOutput.StreamOutputEntriesPointer = new IntPtr(nativeStreamOutElements);
+                    nativeDesc.StreamOutput.EntrieCount = streamOutElements.Length;
+                }
+
                 try
                 {
                     // Create the pipeline state
@@ -267,6 +283,14 @@ namespace SharpDX.Direct3D12
                         for (int i = 0; i < elements.Length; i++)
                         {
                             nativeElements[i].__MarshalFree();
+                        }
+                    }
+
+                    if (streamOutElements != null)
+                    {
+                        for (int i = 0; i < streamOutElements.Length; i++)
+                        {
+                            nativeStreamOutElements[i].__MarshalFree();
                         }
                     }
                 }

--- a/Source/SharpDX.Direct3D12/GpuDescriptorHandle.cs
+++ b/Source/SharpDX.Direct3D12/GpuDescriptorHandle.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpDX.Direct3D12
+{
+    public partial struct GpuDescriptorHandle
+    {
+        /// <summary>
+        ///   Adds an offset to a descriptor handle
+        /// </summary>
+        /// <param name = "left">Initial descriptor handle</param>
+        /// <param name = "right">Offset to apply, use <see cref="SharpDX.Direct3D12.Device.GetDescriptorHandleIncrementSize(DescriptorHeapType)"/> with the relevant heap type.</param>
+        /// <returns>Offsetted descriptor handle</returns>
+        public static GpuDescriptorHandle operator +(GpuDescriptorHandle left, int right)
+        {
+            return new GpuDescriptorHandle()
+            {
+                Ptr = left.Ptr + right
+            };
+        }
+    }
+}

--- a/Source/SharpDX.Direct3D12/GraphicsCommandList.cs
+++ b/Source/SharpDX.Direct3D12/GraphicsCommandList.cs
@@ -41,6 +41,19 @@ namespace SharpDX.Direct3D12
             ClearDepthStencilView(depthStencilView, clearFlags, depth, stencil, 0, null);
         }
 
+        /// <summary>	
+        /// No documentation for Direct3D12	
+        /// </summary>	
+        /// <param name="renderTargetView">No documentation.</param>	
+        /// <param name="colorRGBA">No documentation.</param>		
+        /// <include file='.\..\Documentation\CodeComments.xml' path="/comments/comment[@id='ID3D12GraphicsCommandList::ClearRenderTargetView']/*"/>	
+        /// <unmanaged>void ID3D12GraphicsCommandList::ClearRenderTargetView([In] D3D12_CPU_DESCRIPTOR_HANDLE RenderTargetView,[In] const SHARPDX_COLOR4* ColorRGBA,[In] unsigned int NumRects,[In, Buffer] const RECT* pRects)</unmanaged>	
+        /// <unmanaged-short>ID3D12GraphicsCommandList::ClearRenderTargetView</unmanaged-short>	
+        public void ClearRenderTargetView(CpuDescriptorHandle renderTargetView, Mathematics.Interop.RawColor4 colorRGBA)
+        {
+            ClearRenderTargetView(renderTargetView, colorRGBA, 0, null);
+        }
+
         /// <unmanaged>void ID3D12CommandList::ResourceBarrier([In] unsigned int Count,[In, Buffer] const D3D12_RESOURCE_BARRIER_DESC* pDesc)</unmanaged>	
         /// <unmanaged-short>ID3D12CommandList::ResourceBarrier</unmanaged-short>	
         public void ResourceBarrierTransition(Resource resource, ResourceStates stateBefore, ResourceStates stateAfter)

--- a/Source/SharpDX.Direct3D12/InfoQueue.cs
+++ b/Source/SharpDX.Direct3D12/InfoQueue.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) 2010-2013 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Runtime.InteropServices;
+
+namespace SharpDX.Direct3D12
+{
+    public partial class InfoQueue
+    {
+        public unsafe Message GetMessage(long messageIndex)
+        {
+            PointerSize messageSize = new PointerSize(0);
+            GetMessage(messageIndex, IntPtr.Zero, ref messageSize);
+
+            if (messageSize == 0)
+            {
+                return new Message();
+            }
+
+            var messagePtr = stackalloc byte[(int)messageSize];
+            GetMessage(messageIndex, new IntPtr(messagePtr), ref messageSize);
+
+            var message = new Message();
+            message.__MarshalFrom(ref *(Message.__Native*)messagePtr);
+            return message;
+        }
+    }
+}

--- a/Source/SharpDX.Direct3D12/Mapping.xml
+++ b/Source/SharpDX.Direct3D12/Mapping.xml
@@ -152,6 +152,7 @@
     <!--Remove all fields for D3D12_RESOURCE_BARRIER_DESC as the union with pointers cannot be mapped safely in x86/x64 with C# explicit layout-->
     <remove field="D3D12_RESOURCE_BARRIER::.*"/>
     <remove field="D3D12_ROOT_PARAMETER::.*"/>
+    <remove field="D3D12_TEXTURE_COPY_LOCATION::.*" />
 
     <map interface="ID3D12Debug" name="DebugInterface"/>
 

--- a/Source/SharpDX.Direct3D12/Mapping.xml
+++ b/Source/SharpDX.Direct3D12/Mapping.xml
@@ -127,6 +127,7 @@
     <map field="D3D12_ROOT_CONSTANTS::Num32BitValues" name="Value32BitCount"/>
         
     <map field="D3D12_STREAM_OUTPUT_VIEW_DESC::pSOCurrentOffset" type="void"/>
+
     
     <map struct="D3D12_BLEND_DESC" marshalto="true"/>
 
@@ -138,8 +139,14 @@
     <map struct="D3D12_INPUT_LAYOUT_DESC" struct-to-class="true" marshalto="true"/>
     <map field="D3D12_INPUT_LAYOUT_DESC::pInputElementDescs" name="InputElementsPointer" visibility="private"/>
     <map field="D3D12_INPUT_LAYOUT_DESC::NumElements" visibility="private"/>
-
+    
     <map struct="D3D12_INPUT_ELEMENT_DESC" marshalto="true"/>
+    
+    <map struct="D3D12_STREAM_OUTPUT_DESC" struct-to-class="true" marshalto="true"/>
+    <map field="D3D12_STREAM_OUTPUT_DESC::pSODeclaration" name="StreamOutputEntriesPointer" visibility="private" />
+    <map field="D3D12_STREAM_OUTPUT_DESC::NumEntries" visibility="private"/>
+    
+    <map struct="D3D12_SO_DECLARATION_ENTRY" marshalto="true"/>
 
     <map struct="D3D12_SHADER_BYTECODE" native="true" marshalto="true"/>
     <map field="D3D12_SHADER_BYTECODE::pShaderBytecode" name="Pointer" visibility="private"/>
@@ -148,6 +155,15 @@
     <map struct="D3D12_COMMAND_SIGNATURE" name="CommandSignatureDescription"/>
     
     <map field="D3D12_CLEAR_VALUE::Color" type="SHARPDX_VECTOR4" array="" />
+    
+    <!-- Inner argument description structs have no name, so we specify it manually -->
+    <map struct="D3D12_INDIRECT_ARGUMENT_DESC_INNER_0_INNER_0" name="VertexBufferArgument"/>
+    <map struct="D3D12_INDIRECT_ARGUMENT_DESC_INNER_0_INNER_1" name="ConstantArgument"/>
+    <map struct="D3D12_INDIRECT_ARGUMENT_DESC_INNER_0_INNER_2" name="ConstantBufferArgument"/>
+    <map struct="D3D12_INDIRECT_ARGUMENT_DESC_INNER_0_INNER_3" name="ShaderResourceViewArgument"/>
+    <map struct="D3D12_INDIRECT_ARGUMENT_DESC_INNER_0_INNER_4" name="UnorderedAccessViewArgument"/>
+    <move struct="D3D12_INDIRECT_ARGUMENT_DESC_INNER_(.*)" to="D3D12_INDIRECT_ARGUMENT_DESC"/>
+    
     
     <!--Remove all fields for D3D12_RESOURCE_BARRIER_DESC as the union with pointers cannot be mapped safely in x86/x64 with C# explicit layout-->
     <remove field="D3D12_RESOURCE_BARRIER::.*"/>

--- a/Source/SharpDX.Direct3D12/Message.cs
+++ b/Source/SharpDX.Direct3D12/Message.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpDX.Direct3D12
+{
+    public partial struct Message
+    {
+        // Internal native struct used for marshalling
+        [StructLayout(LayoutKind.Sequential, Pack = 0)]
+        internal partial struct __Native
+        {
+            public SharpDX.Direct3D12.MessageCategory Category;
+            public SharpDX.Direct3D12.MessageSeverity Severity;
+            public SharpDX.Direct3D12.MessageId Id;
+            public System.IntPtr PDescription;
+            public SharpDX.PointerSize DescriptionByteLength;
+        }
+
+        // Method to marshal from native to managed struct
+        internal unsafe void __MarshalFrom(ref __Native @ref)
+        {
+            this.Category = @ref.Category;
+            this.Severity = @ref.Severity;
+            this.Id = @ref.Id;
+            this.Description = (@ref.PDescription == IntPtr.Zero) ? null : Marshal.PtrToStringAnsi(@ref.PDescription, @ref.DescriptionByteLength);
+            this.DescriptionByteLength = @ref.DescriptionByteLength;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("[{0}] [{1}] [{2}] : {3}", Id, Severity, Category, Description);
+        }
+    }
+}

--- a/Source/SharpDX.Direct3D12/SharpDX.Direct3D12.csproj
+++ b/Source/SharpDX.Direct3D12/SharpDX.Direct3D12.csproj
@@ -40,6 +40,7 @@
     <Compile Include="RootParameter.cs" />
     <Compile Include="RootSignatureDescription.cs" />
     <Compile Include="ShaderBytecode.cs" />
+    <Compile Include="TextureCopyLocation.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Documentation\CodeComments.xml" />

--- a/Source/SharpDX.Direct3D12/SharpDX.Direct3D12.csproj
+++ b/Source/SharpDX.Direct3D12/SharpDX.Direct3D12.csproj
@@ -16,7 +16,9 @@
     <Compile Include="BlendStateDescription.cs" />
     <Compile Include="CommandQueue.cs" />
     <Compile Include="CommandQueueDescription.cs" />
+    <Compile Include="CpuDescriptorHandle.cs" />
     <Compile Include="DebugController.cs" />
+    <Compile Include="GpuDescriptorHandle.cs" />
     <Compile Include="GraphicsCommandList.cs" />
     <Compile Include="ComputePipelineStateDescription.cs" />
     <Compile Include="DepthStencilStateDescription.cs" />
@@ -28,9 +30,11 @@
     <Compile Include="Generated\Structures.cs" />
     <Compile Include="GraphicsPipelineStateDescription.cs" />
     <Compile Include="HeapProperties.cs" />
+    <Compile Include="InfoQueue.cs" />
     <Compile Include="InfoQueueFilterDescription.cs" />
     <Compile Include="InputElement.cs" />
     <Compile Include="InputLayoutDescription.cs" />
+    <Compile Include="Message.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RasterizerStateDescription.cs" />
     <Compile Include="ResourceAliasingBarrier.cs" />

--- a/Source/SharpDX.Direct3D12/SharpDX.Direct3D12.csproj
+++ b/Source/SharpDX.Direct3D12/SharpDX.Direct3D12.csproj
@@ -44,6 +44,7 @@
     <Compile Include="RootParameter.cs" />
     <Compile Include="RootSignatureDescription.cs" />
     <Compile Include="ShaderBytecode.cs" />
+    <Compile Include="StreamOutputDescription.cs" />
     <Compile Include="TextureCopyLocation.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/SharpDX.Direct3D12/StreamOutputDescription.cs
+++ b/Source/SharpDX.Direct3D12/StreamOutputDescription.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpDX.Direct3D12
+{
+    public partial class StreamOutputDescription
+    {
+        public StreamOutputDescription() { }
+
+        public StreamOutputDescription(StreamOutputElement[] elements)
+        {
+            Elements = elements;
+        }
+
+        public StreamOutputElement[] Elements { get; set; }
+
+        public int[] Strides { get; set; }
+    }
+}

--- a/Source/SharpDX.Direct3D12/TextureCopyLocation.cs
+++ b/Source/SharpDX.Direct3D12/TextureCopyLocation.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -20,7 +21,7 @@ namespace SharpDX.Direct3D12
         /// <include file='.\..\Documentation\CodeComments.xml' path="/comments/comment[@id='D3D12_TEXTURE_COPY_LOCATION::pResource']/*"/>	
         /// <unmanaged>ID3D12Resource* pResource</unmanaged>	
         /// <unmanaged-short>ID3D12Resource pResource</unmanaged-short>	
-        public System.IntPtr PResource;
+        private System.IntPtr PResource;
 
         /// <summary>	
         /// No documentation.	
@@ -30,13 +31,19 @@ namespace SharpDX.Direct3D12
         /// <unmanaged-short>D3D12_TEXTURE_COPY_TYPE Type</unmanaged-short>	
         public SharpDX.Direct3D12.TextureCopyType Type;
 
+        private Union union;
+
         /// <summary>	
         /// No documentation.	
         /// </summary>	
         /// <include file='.\..\Documentation\CodeComments.xml' path="/comments/comment[@id='D3D12_TEXTURE_COPY_LOCATION::PlacedFootprint']/*"/>	
         /// <unmanaged>D3D12_PLACED_SUBRESOURCE_FOOTPRINT PlacedFootprint</unmanaged>	
         /// <unmanaged-short>D3D12_PLACED_SUBRESOURCE_FOOTPRINT PlacedFootprint</unmanaged-short>	
-        public SharpDX.Direct3D12.PlacedSubResourceFootprint PlacedFootprint;
+        public SharpDX.Direct3D12.PlacedSubResourceFootprint PlacedFootprint
+        {
+            get { return union.PlacedFootprint; }
+            set { union.PlacedFootprint = value; }
+        }
 
         /// <summary>	
         /// No documentation.	
@@ -44,6 +51,38 @@ namespace SharpDX.Direct3D12
         /// <include file='.\..\Documentation\CodeComments.xml' path="/comments/comment[@id='D3D12_TEXTURE_COPY_LOCATION::SubresourceIndex']/*"/>	
         /// <unmanaged>unsigned int SubresourceIndex</unmanaged>	
         /// <unmanaged-short>unsigned int SubresourceIndex</unmanaged-short>	
-        public int SubresourceIndex;
+        public int SubresourceIndex
+        {
+            get { return union.SubResourceIndex; }
+            set { union.SubResourceIndex = value; }
+        }
+
+        public TextureCopyLocation(SharpDX.Direct3D12.Resource resource, int subResourceIndex) : this()
+        {
+            Type = TextureCopyType.SubResourceIndex;
+            PResource = resource != null ? resource.NativePointer : IntPtr.Zero;
+            SubresourceIndex = subResourceIndex;
+        }
+
+        public TextureCopyLocation(SharpDX.Direct3D12.Resource resource, PlacedSubResourceFootprint placedFootprint) : this()
+        {
+            Type = TextureCopyType.PlacedFootprint;
+            PResource = resource != null ? resource.NativePointer : IntPtr.Zero;
+            PlacedFootprint = placedFootprint;
+        }
+
+        /// <summary>
+        /// Because this union contains pointers, it is aligned on 8 bytes boundary, making the field ResourceBarrier.Type 
+        /// to be aligned on 8 bytes instead of 4 bytes, so we can't use directly Explicit layout on ResourceBarrier
+        /// </summary>
+        [StructLayout(LayoutKind.Explicit, Pack = 0)]
+        private partial struct Union
+        {
+            [FieldOffset(0)]
+            public SharpDX.Direct3D12.PlacedSubResourceFootprint PlacedFootprint;
+
+            [FieldOffset(0)]
+            public int SubResourceIndex;
+        }
     }
 }

--- a/Source/SharpDX.Direct3D12/TextureCopyLocation.cs
+++ b/Source/SharpDX.Direct3D12/TextureCopyLocation.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpDX.Direct3D12
+{
+    /// <summary>	
+    /// No documentation for Direct3D12	
+    /// </summary>	
+    /// <include file='.\..\Documentation\CodeComments.xml' path="/comments/comment[@id='D3D12_TEXTURE_COPY_LOCATION']/*"/>	
+    /// <unmanaged>D3D12_TEXTURE_COPY_LOCATION</unmanaged>	
+    /// <unmanaged-short>D3D12_TEXTURE_COPY_LOCATION</unmanaged-short>	
+    public partial struct TextureCopyLocation
+    {
+        /// <summary>	
+        /// No documentation.	
+        /// </summary>	
+        /// <include file='.\..\Documentation\CodeComments.xml' path="/comments/comment[@id='D3D12_TEXTURE_COPY_LOCATION::pResource']/*"/>	
+        /// <unmanaged>ID3D12Resource* pResource</unmanaged>	
+        /// <unmanaged-short>ID3D12Resource pResource</unmanaged-short>	
+        public System.IntPtr PResource;
+
+        /// <summary>	
+        /// No documentation.	
+        /// </summary>	
+        /// <include file='.\..\Documentation\CodeComments.xml' path="/comments/comment[@id='D3D12_TEXTURE_COPY_LOCATION::Type']/*"/>	
+        /// <unmanaged>D3D12_TEXTURE_COPY_TYPE Type</unmanaged>	
+        /// <unmanaged-short>D3D12_TEXTURE_COPY_TYPE Type</unmanaged-short>	
+        public SharpDX.Direct3D12.TextureCopyType Type;
+
+        /// <summary>	
+        /// No documentation.	
+        /// </summary>	
+        /// <include file='.\..\Documentation\CodeComments.xml' path="/comments/comment[@id='D3D12_TEXTURE_COPY_LOCATION::PlacedFootprint']/*"/>	
+        /// <unmanaged>D3D12_PLACED_SUBRESOURCE_FOOTPRINT PlacedFootprint</unmanaged>	
+        /// <unmanaged-short>D3D12_PLACED_SUBRESOURCE_FOOTPRINT PlacedFootprint</unmanaged-short>	
+        public SharpDX.Direct3D12.PlacedSubResourceFootprint PlacedFootprint;
+
+        /// <summary>	
+        /// No documentation.	
+        /// </summary>	
+        /// <include file='.\..\Documentation\CodeComments.xml' path="/comments/comment[@id='D3D12_TEXTURE_COPY_LOCATION::SubresourceIndex']/*"/>	
+        /// <unmanaged>unsigned int SubresourceIndex</unmanaged>	
+        /// <unmanaged-short>unsigned int SubresourceIndex</unmanaged-short>	
+        public int SubresourceIndex;
+    }
+}


### PR DESCRIPTION
Hello, this one was also missing in latest build and had explicit layout (but has a pointer to a resource)

Removed fields from mapping and added them in partial class instead

Thanks
Julien