### PR TITLE
[SharpDX.D3DCompiler] Small issue with library profile

### DIFF
--- a/Source/SharpDX.D3DCompiler/ShaderBytecode.cs
+++ b/Source/SharpDX.D3DCompiler/ShaderBytecode.cs
@@ -360,7 +360,7 @@ namespace SharpDX.D3DCompiler
                 if (string.IsNullOrWhiteSpace(profile))
                     throw new ArgumentNullException("profile");
 
-                if (!profile.ToUpperInvariant().StartsWith("FX_") && string.IsNullOrWhiteSpace(entryPoint))
+                if (!(profile.ToUpperInvariant().StartsWith("FX_") || profile.ToUpperInvariant().StartsWith("LIB_")) && string.IsNullOrWhiteSpace(entryPoint))
                     throw new ArgumentNullException("entryPoint");
 
                 var resultCode = Result.Ok;


### PR DESCRIPTION
Hello,
I noticed on last build the Compile function was checking that only FX profile could have a null entry point.

Since Library profile is also allowed to have no profile, I added the condition in there

Thanks
