### PR TITLE
[D3DCompiler] Shader requirements enum

### DIFF
--- a/Source/SharpDX.D3DCompiler/Mapping.xml
+++ b/Source/SharpDX.D3DCompiler/Mapping.xml
@@ -77,6 +77,10 @@
     <create class="D3D" />
 
     <context-clear/>
+
+    <context>d3d12shader</context>
+    <create-cpp enum="D3DCOMPILE_SHADER_REQUIRES_FLAGS" macro="D3D_SHADER_REQUIRES_.*" />
+    <context-clear/>
   </extension>
   
   <bindings>
@@ -171,6 +175,8 @@
     <map method="ID3D11ShaderReflectionType::GetInterfaceByIndex" name="GetInterface" />
     <map method="ID3D11ShaderReflectionType::GetMemberTypeBy.*" name="GetMemberType" />
     <map method="ID3D11ShaderReflectionType::ImplementsInterface" visibility="internal" name="ImplementsInterface_" return="true" check="false"/>
+
+    <map method="ID3D11ShaderReflection::GetRequiresFlags" type="D3DCOMPILE_SHADER_REQUIRES_FLAGS" />
     
     <map method="ID3D11ShaderReflectionType::IsEqual" visibility="internal" name="IsEqual_"  return="true" check="false"/>
     <map method="ID3D11ShaderReflectionType::IsOfType" visibility="internal" name="IsOfType_" return="true" check="false"/>

--- a/Source/SharpDX.D3DCompiler/Mapping.xml
+++ b/Source/SharpDX.D3DCompiler/Mapping.xml
@@ -49,6 +49,7 @@
     <attach>D3D_SHADER_INPUT_FLAGS</attach>
     <attach>D3D_NAME</attach>
     <attach>D3D_REGISTER_COMPONENT_TYPE</attach>
+    <attach>D3D_PARAMETER_FLAGS</attach>
     <attach>ID3DInclude</attach>
     <attach>D3D_INCLUDE_TYPE</attach>
     <attach>D3DCreateBlob</attach>
@@ -90,6 +91,7 @@
   <mapping>
     <context>d3dcommon</context>
     <remove enum-item="D3D10_CBF_USERPACKED" />
+    <map enum-item="D3D_PF(.*)" name-tmp="$1" />
     <context-clear />
     
     <context id="d3dcompiler-all"/>
@@ -100,7 +102,6 @@
     -->
     <map enum="D3D(.*)" name-tmp="$1" />
     <map enum-item="D3D(.*)" name-tmp="$1" />
-    <map enum-item="D3D_PF(.*)" name-tmp="$1" />
     <map enum="D3DCOMPILE_(.+)" name-tmp="$1" />
     <map enum="D3DCOMPILER_(.+)" name-tmp="$1" />
     <map enum="D3D11(.*)" name-tmp="$1" />


### PR DESCRIPTION
Hello, 

another small pull request to get flag requirements from shader reflection as typed enum instead of long.
I get the enum from d3d12shader.h in order to get the extra flags.

Thanks