### PR TITLE
[SharpDX.Direct3D11] Added DirectX11.3 support

### DIFF
--- a/Source/Mapping.Direct3D1x.xml
+++ b/Source/Mapping.Direct3D1x.xml
@@ -53,6 +53,7 @@
     <context>d3d11</context>
     <context>d3d11_1</context>
     <context>d3d11_2</context>
+    <context>d3d11_3</context>
     <context>d3d12</context>
     <context>d3d12sdklayers</context>
     <context>d3d11sdklayers</context>
@@ -142,6 +143,7 @@
     <map struct="D3D(\d+)_BLEND_DESC1" name="BlendStateDescription1" />
     <map struct="D3D(\d+)_RASTERIZER_DESC" name="RasterizerStateDescription" />
     <map struct="D3D(\d+)_RASTERIZER_DESC1" name="RasterizerStateDescription1" />
+    <map struct="D3D(\d+)_RASTERIZER_DESC2" name="RasterizerStateDescription2" />
     <map struct="D3D(\d+)_SAMPLER_DESC" name="SamplerStateDescription" />
     <map field="D3D(\d+)_SAMPLER_DESC::BorderColor" type="SHARPDX_COLOR4" array="0" />
     <map field="D3D(\d+)_SAMPLER_DESC::MaxAnisotropy" name="MaximumAnisotropy" />
@@ -173,16 +175,19 @@
     <map struct="D3D(\d+)_(.*)_SRV1" name-tmp="$2_Resource1" />
     <move struct="D3D(\d+)_(.*)_SRV1" to="D3D$1_SHADER_RESOURCE_VIEW_DESC1"/>
     
-    <map struct="D3D(\d+)_(.*)_RTV" name-tmp="$2_Resource" />
+    <map struct="D3D(\d+)_(.*)_RTV1?" name-tmp="$2_Resource" />
     <move struct="D3D(\d+)_(.*)_RTV" to="D3D$1_RENDER_TARGET_VIEW_DESC"/>
+    <move struct="D3D(\d+)_(.*)_RTV1" to="D3D$1_RENDER_TARGET_VIEW_DESC1"/>
+
     <map field="D3D(\d+)_TEX3D_RTV::FirstWSlice" name="FirstDepthSlice" />
     <map field="D3D(\d+)_TEX3D_RTV::WSize" name="DepthSliceCount" />
 
     <map struct="D3D(\d+)_(.*)_DSV" name-tmp="$2_Resource" />
     <move struct="D3D(\d+)_(.*)_DSV" to="D3D$1_DEPTH_STENCIL_VIEW_DESC"/>
     
-    <map struct="D3D(\d+)_(.*)_UAV" name-tmp="$2_Resource" />
+    <map struct="D3D(\d+)_(.*)_UAV1?" name-tmp="$2_Resource" />
     <move struct="D3D(\d+)_(.*)_UAV" to="D3D$1_UNORDERED_ACCESS_VIEW_DESC"/>
+    <move struct="D3D(\d+)_(.*)_UAV1" to="D3D$1_UNORDERED_ACCESS_VIEW_DESC1"/>
 
     <map field="D3D(\d+)_.*::ViewDimension" name="Dimension" />    
     <map struct="D3DX?(\d+)_PASS_DESC" name="EffectPassDescription" />
@@ -195,12 +200,12 @@
     <map field="D3D(\d+)_TEXTURE1D_DESC::BindFlags" type="D3D$1_BIND_FLAG" />
     <map field="D3D(\d+)_TEXTURE1D_DESC::CPUAccessFlags" name="CpuAccessFlags" type="D3D$1_CPU_ACCESS_FLAG" />
     <map field="D3D(\d+)_TEXTURE1D_DESC::MiscFlags" name="OptionFlags" type="D3D$1_RESOURCE_MISC_FLAG" />
-    <map field="D3D(\d+)_TEXTURE2D_DESC::BindFlags" type="D3D$1_BIND_FLAG" />
-    <map field="D3D(\d+)_TEXTURE2D_DESC::CPUAccessFlags" name="CpuAccessFlags" type="D3D$1_CPU_ACCESS_FLAG" />
-    <map field="D3D(\d+)_TEXTURE2D_DESC::MiscFlags" name="OptionFlags" type="D3D$1_RESOURCE_MISC_FLAG" />
-    <map field="D3D(\d+)_TEXTURE3D_DESC::BindFlags" type="D3D$1_BIND_FLAG" />
-    <map field="D3D(\d+)_TEXTURE3D_DESC::CPUAccessFlags" name="CpuAccessFlags" type="D3D$1_CPU_ACCESS_FLAG" />
-    <map field="D3D(\d+)_TEXTURE3D_DESC::MiscFlags" name="OptionFlags" type="D3D$1_RESOURCE_MISC_FLAG" />
+    <map field="D3D(\d+)_TEXTURE2D_DESC1?::BindFlags" type="D3D$1_BIND_FLAG" />
+    <map field="D3D(\d+)_TEXTURE2D_DESC1?::CPUAccessFlags" name="CpuAccessFlags" type="D3D$1_CPU_ACCESS_FLAG" />
+    <map field="D3D(\d+)_TEXTURE2D_DESC1?::MiscFlags" name="OptionFlags" type="D3D$1_RESOURCE_MISC_FLAG" />
+    <map field="D3D(\d+)_TEXTURE3D_DESC1?::BindFlags" type="D3D$1_BIND_FLAG" />
+    <map field="D3D(\d+)_TEXTURE3D_DESC1?::CPUAccessFlags" name="CpuAccessFlags" type="D3D$1_CPU_ACCESS_FLAG" />
+    <map field="D3D(\d+)_TEXTURE3D_DESC1?::MiscFlags" name="OptionFlags" type="D3D$1_RESOURCE_MISC_FLAG" />
     <map field="D3D(\d+)_FEATURE_DATA_FORMAT_SUPPORT::OutFormatSupport" type="D3D$1_FORMAT_SUPPORT" />
     <map field="D3D(\d+)_FEATURE_DATA_FORMAT_SUPPORT2::OutFormatSupport2" type="D3D$1_FORMAT_SUPPORT2" />
     <map field="D3DX(\d+)_IMAGE_INFO::MiscFlags" type="D3D$1_RESOURCE_MISC_FLAG" />
@@ -255,8 +260,9 @@
     <map field="D3DX?(\d+)_EFFECT_SHADER_DESC::NumOutputSignatureEntries" name="OutputParameterCount" />
     <map field="D3D(X?\d+)_EFFECT_VARIABLE_DESC::Flags" type="D3D$1_EFFECT_VARIABLE_FLAGS" />
     <map field="D3DX?(\d+)_EFFECT_VARIABLE_DESC::Annotations" name="AnnotationCount" />
-    <map field="D3D(\d+)_RASTERIZER_DESC1?::(.*)Enable" name="Is$2Enabled" />
-    <map field="D3D(\d+)_RASTERIZER_DESC1?::FrontCounterClockwise" name="IsFrontCounterClockwise" />
+    <map field="D3D(\d+)_RASTERIZER_DESC[12]?::(.*)Enable" name="Is$2Enabled" />
+    <map field="D3D(\d+)_RASTERIZER_DESC[12]?::FrontCounterClockwise" name="IsFrontCounterClockwise" />
+    <map field="D3D(\d+)_RASTERIZER_DESC2::ConservativeRaster" name="ConservativeRasterizationMode" />
     <map field="D3D(\d+)_RENDER_TARGET_BLEND_DESC1?::BlendEnable" name="IsBlendEnabled" />
     <map field="D3D(\d+)_RENDER_TARGET_BLEND_DESC1?::SrcBlend" name="SourceBlend" />
     <map field="D3D(\d+)_RENDER_TARGET_BLEND_DESC1?::DestBlend" name="DestinationBlend" />
@@ -277,7 +283,7 @@
     // D3D1x Interfaces
     // *****************************************************************
     -->
-    <map interface="ID3D1[0-2](.+)" name-tmp="$1" />
+    <map interface="ID3D1[0-3](.+)" name-tmp="$1" />
     <map interface="ID3DX10(.+)" name-tmp="$1" />
     <map interface="ID3DX11(.+)" name-tmp="$1" />
 
@@ -310,9 +316,9 @@
     <map method="ID3D(\d+)Device::GetDeviceRemovedReason" check="false"/>
     
     <map method="ID3D(\d+)Device::CheckCounter" visibility="internal"/>
-    <map method="ID3D(\d+)Device[12]?::Create.*" visibility="internal" />
-    <map param="ID3D(\d+)Device[12]?::Create.*::pp.*" attribute="out fast" />
-    <map method="ID3D(\d+)Device[12]?::GetImmediateContext[12]?" persist="true"/>
+    <map method="ID3D(\d+)Device[123]?::Create.*" visibility="internal" />
+    <map param="ID3D(\d+)Device[123]?::Create.*::pp.*" attribute="out fast" />
+    <map method="ID3D(\d+)Device[123]?::GetImmediateContext[123]?" persist="true"/>
     <remove method="ID3D(\d+)Device::.*TextFilterSize" />
     <map method="ID3D(\d+)Device::GetPredication" visibility="internal" />
     <map method="ID3D(\d+)Device1?::OpenSharedResource1?" visibility="internal" />

--- a/Source/SharpDX.Direct3D11/Device.cs
+++ b/Source/SharpDX.Direct3D11/Device.cs
@@ -380,6 +380,38 @@ namespace SharpDX.Direct3D11
         }
 
         /// <summary>
+        /// Retrieves information about Direct3D11.3 feature options in the current graphics driver
+        /// </summary>
+        /// <msdn-id>dn879499</msdn-id>
+        /// <returns>Returns a structure <see cref="FeatureDataD3D11Options2"/> </returns>	
+        public FeatureDataD3D11Options2 CheckD3D113Features2()
+        {
+            unsafe
+            {
+                var support = default(FeatureDataD3D11Options2);
+                if (CheckFeatureSupport(Feature.D3D11Options2, new IntPtr(&support), Utilities.SizeOf<FeatureDataD3D11Options2>()).Failure)
+                    return default(FeatureDataD3D11Options2);
+                return support;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves additional information about Direct3D11.3 feature options in the current graphics driver
+        /// </summary>
+        /// <msdn-id>dn933226</msdn-id>
+        /// <returns>Returns a structure <see cref="FeatureDataD3D11Options3"/> </returns>	
+        public FeatureDataD3D11Options3 CheckD3D113Features3()
+        {
+            unsafe
+            {
+                var support = default(FeatureDataD3D11Options3);
+                if (CheckFeatureSupport(Feature.D3D11Options3, new IntPtr(&support), Utilities.SizeOf<FeatureDataD3D11Options3>()).Failure)
+                    return default(FeatureDataD3D11Options3);
+                return support;
+            }
+        }
+
+        /// <summary>
         /// Check if this device is supporting a feature.
         /// </summary>
         /// <param name="feature">The feature to check.</param>

--- a/Source/SharpDX.Direct3D11/Device3.cs
+++ b/Source/SharpDX.Direct3D11/Device3.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+namespace SharpDX.Direct3D11
+{
+    public partial class Device3
+    {
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (ImmediateContext3__ != null)
+                {
+                    ImmediateContext3__.Dispose();
+                    ImmediateContext3__ = null;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Source/SharpDX.Direct3D11/Mapping.xml
+++ b/Source/SharpDX.Direct3D11/Mapping.xml
@@ -40,6 +40,7 @@
   <include file="d3d11.h" attach="true"/>
   <include file="d3d11_1.h" attach="true" />
   <include file="d3d11_2.h" attach="true" />
+  <include file="d3d11_3.h" attach="true" />
   <include file="d3d11sdklayers.h" attach="true" />
 
   <naming />
@@ -51,6 +52,7 @@
     <context>d3d11sdklayers</context>
     <context>d3d11_1</context>
     <context>d3d11_2</context>
+    <context>d3d11_3</context>
   </context-set>
 
   <!-- D3D11 extensions -->
@@ -154,6 +156,9 @@
     
     <map enum-item="D3D11_VIDEO_PROCESSOR_NOMINAL_RANGE_16_235" name="Range_16_235"/>
     <map enum-item="D3D11_VIDEO_PROCESSOR_NOMINAL_RANGE_0_255" name="Range_0_255"/>
+
+    <map enum-item="D3D11_CONTEXT_TYPE_3D" name="ThreeDimensions" />
+    <map enum-item="D3D11_TEXTURE_LAYOUT_64K_STANDARD_SWIZZLE" name="StandardSwizzle64kb" />
 
     <map enum-item="D3D11_(MESSAGE_ID.*)" name-tmp="$1" />
     <map enum-item="D3D12_(MESSAGE_ID.*)" name-tmp="$1" />

--- a/Source/SharpDX.Direct3D11/Mapping.xml
+++ b/Source/SharpDX.Direct3D11/Mapping.xml
@@ -178,7 +178,7 @@
     <map struct="D3D11_FEATURE_DATA_.*" visibility="internal" />
     
     <map struct="D3D11_FEATURE_DATA_D3D11_OPTIONS" visibility="public" />
-    <map struct="D3D11_FEATURE_DATA_D3D11_OPTIONS1" visibility="public" />
+    <map struct="D3D11_FEATURE_DATA_D3D11_OPTIONS[123]" visibility="public" />
     <map struct="D3D11_FEATURE_DATA_SHADER_MIN_PRECISION_SUPPORT" visibility="public" />
 
     <map field="D3DX11_IMAGE_INFO::pSrcInfo" visibility="internal" />

--- a/Source/SharpDX.Direct3D11/RasterizerState2.cs
+++ b/Source/SharpDX.Direct3D11/RasterizerState2.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace SharpDX.Direct3D11
+{
+    public partial class RasterizerState2
+    {
+        /// <summary>
+        ///   Constructs a new <see cref = "T:SharpDX.Direct3D11.RasterizerState2" /> based on the specified description.
+        /// </summary>
+        /// <param name = "device">The device with which to associate the state object.</param>
+        /// <param name = "description">The state description.</param>
+        /// <returns>The newly created object.</returns>
+        public RasterizerState2(Device3 device, RasterizerStateDescription2 description)
+            : base(IntPtr.Zero)
+        {
+            device.CreateRasterizerState2(ref description, this);
+        }
+    }
+}

--- a/Source/SharpDX.Direct3D11/SharpDX.Direct3D11.csproj
+++ b/Source/SharpDX.Direct3D11/SharpDX.Direct3D11.csproj
@@ -25,6 +25,7 @@
     <Compile Include="Device2.cs" />
     <Compile Include="Device3.cs" />
     <Compile Include="DeviceContext2.cs" />
+    <Compile Include="RasterizerState2.cs" />
     <Compile Include="RasterizerStateDescription1.cs" />
     <Compile Include="DepthStencilStateDescription.cs" />
     <Compile Include="Device1.cs" />

--- a/Source/SharpDX.Direct3D11/SharpDX.Direct3D11.csproj
+++ b/Source/SharpDX.Direct3D11/SharpDX.Direct3D11.csproj
@@ -23,6 +23,7 @@
     <Compile Include="BlendState1.cs" />
     <Compile Include="BlendStateDescription1.cs" />
     <Compile Include="Device2.cs" />
+    <Compile Include="Device3.cs" />
     <Compile Include="DeviceContext2.cs" />
     <Compile Include="RasterizerStateDescription1.cs" />
     <Compile Include="DepthStencilStateDescription.cs" />


### PR DESCRIPTION
Hello, since I noticed it was missing, I added mappings for directx11.3.

I tried to reuse the existing regular expressions instead of adding new ones, and naming should be consistent with other features.


Thanks