### PR TITLE
Fixing x64 and Windows 10 startup issues

### DIFF
--- a/Source/SharedAssemblyInfo.cs
+++ b/Source/SharedAssemblyInfo.cs
@@ -28,8 +28,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly:AssemblyVersion("2.6.3")]
-[assembly:AssemblyFileVersion("2.6.3")]
+[assembly:AssemblyVersion("2.6.3.1")]
+[assembly:AssemblyFileVersion("2.6.3.1")]
 
 [assembly: NeutralResourcesLanguage("en-us")]
 

--- a/Source/Toolkit/SharpDX.Toolkit.Input/PointerPlatformDesktopTouch.cs
+++ b/Source/Toolkit/SharpDX.Toolkit.Input/PointerPlatformDesktopTouch.cs
@@ -50,7 +50,10 @@ namespace SharpDX.Toolkit.Input
         {
             // touch is not supported for OS below Windows 7
             var osVersion = Environment.OSVersion.Version;
-            if (osVersion.Major < 6 || osVersion.Major >= 6 && osVersion.Minor < 1) return;
+
+            // Fixing Windows10 recognition
+            if (osVersion.Major < 6 || 
+                (osVersion.Major == 6 && osVersion.Minor < 1)) return;
 
             // inform OS that we can handle correctly DPI
             // TODO: check if we need this here
@@ -145,7 +148,8 @@ namespace SharpDX.Toolkit.Input
                 case User32.WM_RBUTTONDOWN:
                 case User32.WM_RBUTTONUP:
                 case User32.WM_MOUSEMOTION:
-                    if ((User32.GetMessageExtraInfo().ToInt32() & User32.MOUSEEVENTF_FROMTOUCH) == User32.MOUSEEVENTF_FROMTOUCH)
+                    // Fixing x64 message processing
+                    if ((User32.GetMessageExtraInfo().ToInt64() & User32.MOUSEEVENTF_FROMTOUCH) == User32.MOUSEEVENTF_FROMTOUCH)
                         return 1;
                     break;
             }


### PR DESCRIPTION
Fix for legacy version 2.6.3; solves touch input processing when running in x64 mode and fixes Windows 10 operating system check which incorrectly prevents processing of touch events.