### PR TITLE
[Direct2D1] change mapping for Direct2D1.3

### DIFF
--- a/Source/SharpDX.Direct2D1/CommandSink2.cs
+++ b/Source/SharpDX.Direct2D1/CommandSink2.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using SharpDX.Mathematics.Interop;
+
+namespace SharpDX.Direct2D1
+{
+    public partial interface CommandSink2
+    {
+        /// <summary>	
+        /// No documentation for Direct3D12	
+        /// </summary>	
+        /// <param name="ink">No documentation.</param>	
+        /// <param name="brush">No documentation.</param>	
+        /// <param name="inkStyle">No documentation.</param>	
+        /// <returns>No documentation.</returns>	
+        /// <include file='.\Documentation\CodeComments.xml' path="/comments/comment[@id='ID2D1CommandSink2::DrawInk']/*"/>	
+        /// <unmanaged>HRESULT ID2D1CommandSink2::DrawInk([In] ID2D1Ink* ink,[In] ID2D1Brush* brush,[In, Optional] ID2D1InkStyle* inkStyle)</unmanaged>	
+        /// <unmanaged-short>ID2D1CommandSink2::DrawInk</unmanaged-short>	
+        void DrawInk(Ink ink, Brush brush, InkStyle inkStyle);
+        /// <summary>	
+        /// No documentation for Direct3D12	
+        /// </summary>	
+        /// <param name="gradientMesh">No documentation.</param>	
+        /// <returns>No documentation.</returns>	
+        /// <include file='.\Documentation\CodeComments.xml' path="/comments/comment[@id='ID2D1CommandSink2::DrawGradientMesh']/*"/>	
+        /// <unmanaged>HRESULT ID2D1CommandSink2::DrawGradientMesh([In] ID2D1GradientMesh* gradientMesh)</unmanaged>	
+        /// <unmanaged-short>ID2D1CommandSink2::DrawGradientMesh</unmanaged-short>	
+        void DrawGradientMesh(GradientMesh gradientMesh);
+        /// <summary>	
+        /// No documentation for Direct3D12	
+        /// </summary>	
+        /// <param name="gdiMetafile">No documentation.</param>	
+        /// <param name="destinationRectangle">No documentation.</param>	
+        /// <param name="sourceRectangle">No documentation.</param>	
+        /// <returns>No documentation.</returns>	
+        /// <include file='.\Documentation\CodeComments.xml' path="/comments/comment[@id='ID2D1CommandSink2::DrawGdiMetafile']/*"/>	
+        /// <unmanaged>HRESULT ID2D1CommandSink2::DrawGdiMetafile([In] ID2D1GdiMetafile* gdiMetafile,[In, Optional] const D2D_RECT_F* destinationRectangle,[In, Optional] const D2D_RECT_F* sourceRectangle)</unmanaged>	
+        /// <unmanaged-short>ID2D1CommandSink2::DrawGdiMetafile</unmanaged-short>	
+        void DrawGdiMetafile(GdiMetafile gdiMetafile, RawRectangleF? destinationRectangle, RawRectangleF? sourceRectangle);
+    }
+}

--- a/Source/SharpDX.Direct2D1/CommandSink2Native.cs
+++ b/Source/SharpDX.Direct2D1/CommandSink2Native.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using SharpDX.Mathematics.Interop;
+
+namespace SharpDX.Direct2D1
+{
+    internal partial class CommandSink2Native
+    {
+        /// <summary>	
+        /// No documentation for Direct3D12	
+        /// </summary>	
+        /// <param name="ink">No documentation.</param>	
+        /// <param name="brush">No documentation.</param>	
+        /// <param name="inkStyle">No documentation.</param>	
+        /// <returns>No documentation.</returns>	
+        /// <include file='.\Documentation\CodeComments.xml' path="/comments/comment[@id='ID2D1CommandSink2::DrawInk']/*"/>	
+        /// <unmanaged>HRESULT ID2D1CommandSink2::DrawInk([In] ID2D1Ink* ink,[In] ID2D1Brush* brush,[In, Optional] ID2D1InkStyle* inkStyle)</unmanaged>	
+        /// <unmanaged-short>ID2D1CommandSink2::DrawInk</unmanaged-short>	
+        public void DrawInk(Ink ink, Brush brush, InkStyle inkStyle)
+        {
+            DrawInk_(ink, brush, inkStyle);
+        }
+        /// <summary>	
+        /// No documentation for Direct3D12	
+        /// </summary>	
+        /// <param name="gradientMesh">No documentation.</param>	
+        /// <returns>No documentation.</returns>	
+        /// <include file='.\Documentation\CodeComments.xml' path="/comments/comment[@id='ID2D1CommandSink2::DrawGradientMesh']/*"/>	
+        /// <unmanaged>HRESULT ID2D1CommandSink2::DrawGradientMesh([In] ID2D1GradientMesh* gradientMesh)</unmanaged>	
+        /// <unmanaged-short>ID2D1CommandSink2::DrawGradientMesh</unmanaged-short>	
+        public void DrawGradientMesh(GradientMesh gradientMesh)
+        {
+            DrawGradientMesh_(gradientMesh);
+        }
+        /// <summary>	
+        /// No documentation for Direct3D12	
+        /// </summary>	
+        /// <param name="gdiMetafile">No documentation.</param>	
+        /// <param name="destinationRectangle">No documentation.</param>	
+        /// <param name="sourceRectangle">No documentation.</param>	
+        /// <returns>No documentation.</returns>	
+        /// <include file='.\Documentation\CodeComments.xml' path="/comments/comment[@id='ID2D1CommandSink2::DrawGdiMetafile']/*"/>	
+        /// <unmanaged>HRESULT ID2D1CommandSink2::DrawGdiMetafile([In] ID2D1GdiMetafile* gdiMetafile,[In, Optional] const D2D_RECT_F* destinationRectangle,[In, Optional] const D2D_RECT_F* sourceRectangle)</unmanaged>	
+        /// <unmanaged-short>ID2D1CommandSink2::DrawGdiMetafile</unmanaged-short>	
+        public void DrawGdiMetafile(GdiMetafile gdiMetafile, RawRectangleF? destinationRectangle, RawRectangleF? sourceRectangle)
+        {
+            DrawGdiMetafile_(gdiMetafile, destinationRectangle, sourceRectangle);
+        }
+    }
+}

--- a/Source/SharpDX.Direct2D1/Device2.cs
+++ b/Source/SharpDX.Direct2D1/Device2.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+
+namespace SharpDX.Direct2D1
+{
+    public partial class Device2
+    {
+        /// <summary>	
+        /// Initializes a new instance of the <see cref="Device2"/> class.
+        /// </summary>	
+        /// <param name="factory"><para>The <see cref="Factory3"/> object used when creating  the <see cref="SharpDX.Direct2D1.Device2"/>. </para></param>	
+        /// <param name="device"><para>The <see cref="SharpDX.DXGI.Device"/> object used when creating  the <see cref="SharpDX.Direct2D1.Device2"/>. </para></param>	
+        /// <remarks>	
+        /// Each call to CreateDevice returns a unique <see cref="SharpDX.Direct2D1.Device2"/> object.The <see cref="SharpDX.DXGI.Device"/> object is obtained by calling QueryInterface on an ID3D10Device or an ID3D11Device.	
+        /// </remarks>	
+        /// <unmanaged>HRESULT ID2D1Factory3::CreateDevice([In] IDXGIDevice* dxgiDevice,[Out] ID2D1Device2** d2dDevice2)</unmanaged>	
+        public Device2(Factory3 factory, SharpDX.DXGI.Device device)
+            : base(IntPtr.Zero)
+        {
+            factory.CreateDevice(device, this);
+        }
+    }
+}

--- a/Source/SharpDX.Direct2D1/DeviceContext2.cs
+++ b/Source/SharpDX.Direct2D1/DeviceContext2.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+
+namespace SharpDX.Direct2D1
+{
+    public partial class DeviceContext2
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeviceContext2"/> class using an existing <see cref="Device2"/>.
+        /// </summary>
+        /// <param name="device">The device.</param>
+        /// <param name="options">The options to be applied to the created device context.</param>
+        /// <remarks>
+        /// The new device context will not have a  selected target bitmap. The caller must create and select a bitmap as the target surface of the context.
+        /// </remarks>
+        /// <unmanaged>HRESULT ID2D1Device2::CreateDeviceContext([In] D2D1_DEVICE_CONTEXT_OPTIONS options,[Out] ID2D1DeviceContext2** deviceContext2)</unmanaged>
+        public DeviceContext2(Device2 device, DeviceContextOptions options)
+            : base(IntPtr.Zero)
+        {
+            device.CreateDeviceContext(options, this);
+        }
+    }
+}

--- a/Source/SharpDX.Direct2D1/Mapping-direct2d1.xml
+++ b/Source/SharpDX.Direct2D1/Mapping-direct2d1.xml
@@ -40,6 +40,9 @@
   <include file="d2d1effectauthor.h" attach="true" />
   <include file="d2d1_2.h" attach="true" />
   <include file="d2d1effects_1.h" attach="true" />
+  <include file="d2d1effectauthor_1.h" attach="true" />
+  <include file="d2d1_3.h" attach="true" />
+  <include file="d2d1effects_2.h" attach="true" />
 
   <naming />
   
@@ -50,9 +53,12 @@
     <context>d2derr</context>
     <context>d2d1_1</context>
     <context>d2d1_2</context>
+    <context>d2d1_3</context>
     <context>d2d1effects</context>
     <context>d2d1effects_1</context>
+    <context>d2d1effects_2</context>
     <context>d2d1effectauthor</context>
+    <context>d2d1effectauthor_1</context>
     
     <const from-guid="CLSID_D2D1([A-Z].*)" class="SharpDX.Direct2D1.Effect" type="System.Guid" name="$1">new System.Guid("$1")</const>
     <const from-guid="CLSID_D2D12DAffineTransform" class="SharpDX.Direct2D1.Effect" type="System.Guid" name="AffineTransform2D">new System.Guid("$1")</const>
@@ -90,9 +96,12 @@
     <context>d2d1</context>
     <context>d2d1_1</context>
     <context>d2d1_2</context>
+    <context>d2d1_3</context>
     <context>d2d1effects</context>
     <context>d2d1effects_1</context>
+    <context>d2d1effects_2</context>
     <context>d2d1effectauthor</context>
+    <context>d2d1effectauthor_1</context>
 
     <!--
     // *****************************************************************
@@ -190,6 +199,27 @@
 
     <map enum="D2D1_YCBCR_INTERPOLATION_MODE" name="YcbcrInterpolationMode" />
 
+    <!-- Added in Direct2D1.3 -->
+    <map enum="D2D1_CHROMAKEY_PROP" name="ChromakeyProperty" />
+    <map enum="D2D1_CONTRAST_PROP" name="ContrastProperty" />
+    <map enum="D2D1_EDGEDETECTION_MODE" name="EdgeDetectionMode" />
+    <map enum="D2D1_EDGEDETECTION_PROP" name="EdgeDetectionProperty" />
+    <map enum="D2D1_EMBOSS_PROP" name="EmbossProperty" />
+    <map enum="D2D1_EXPOSURE_PROP" name="ExposureProperty" />
+    <map enum="D2D1_HIGHLIGHTSANDSHADOWS_INPUT_GAMMA" name="HighlightSandShadowsInputGamma" />
+    <map enum="D2D1_HIGHLIGHTSANDSHADOWS_PROP" name="HighlightSandShadowsProperty" />
+    <map enum="D2D1_HUETORGB_INPUT_COLOR_SPACE" name="HueToRgbInputColorSpace" />
+    <map enum="D2D1_HUETORGB_PROP" name="HueToRgbProperty" />
+    <map enum="D2D1_LOOKUPTABLE3D_PROP" name="LookupTable3DProperty" />
+    <map enum="D2D1_POSTERIZE_PROP" name="PosterizeProperty" />
+    <map enum="D2D1_RGBTOHUE_OUTPUT_COLOR_SPACE" name="RgbToHueOutputColorSpace" />
+    <map enum="D2D1_RGBTOHUE_PROP" name="RgbToHueProperty" />
+    <map enum="D2D1_SEPIA_PROP" name="SepiaProperty" />
+    <map enum="D2D1_SHARPEN_PROP" name="SharpenProperty" />
+    <map enum="D2D1_STRAIGHTEN_PROP" name="StraightenProperty" />
+    <map enum="D2D1_TEMPERATUREANDTINT_PROP" name="TemperatureAndTintProperty" />
+    <map enum="D2D1_VIGNETTE_PROP" name="VignetteProperty" />
+      
     <!--
     // *****************************************************************
     // D2D1 Structures
@@ -254,7 +284,7 @@
     <map method="ID2D1Factory::GetDesktopDpi" visibility="internal" />
     <map method="ID2D(\d+)Factory\d?::Create.*" visibility="internal" />
 
-    <map param="ID2D1Factory[12]::CreateDevice::d2dDevice1?" attribute="out fast"/>
+    <map param="ID2D1Factory[123]::CreateDevice::d2dDevice[123]?" attribute="out fast"/>
     <map param="ID2D1Factory1::CreateStrokeStyle::strokeStyle" attribute="out fast"/>
     <map param="ID2D1Factory1::CreatePathGeometry::pathGeometry" attribute="out fast"/>
     <map param="ID2D1Factory1::CreateDrawingStateBlock::drawingStateBlock" attribute="out fast"/>
@@ -277,7 +307,7 @@
     <map param="ID2D(\d+)Factory::CreateWicBitmapRenderTarget::renderTarget" attribute="out fast"/>
 
     <map method="ID2D\dDevice1?::Create.*" visibility="internal"/>
-    <map param="ID2D\dDevice1?::CreateDeviceContext::deviceContext1?" attribute="out fast"/>
+    <map param="ID2D\dDevice[12]?::CreateDeviceContext::deviceContext[12]?" attribute="out fast"/>
     <map param="ID2D\dDevice::CreatePrintControl::printControl" attribute="out fast"/>
 
     <map method="ID2D\dDeviceContext1?::Create.*" visibility="internal"/>
@@ -333,6 +363,7 @@
     <map method="ID2D1RenderTarget::(.*)Dpi" visibility="internal" />
     <map method="ID2D(\d+)Mesh::Open" visibility="internal" name="Open_" />
     <map interface="ID2D(\d+).*Sink1?" callback="true" callback-dual="true" />
+    <map interface="ID2D(\d+).*Sink2?" callback="true" callback-dual="true" />
 
     <!--<map param="ID2D1DeviceContext::CreateColorContextFromWicColorContext::wicColorContext" type="IUnknown"/>
     <map param="ID2D1DeviceContext::CreateColorContextFromWicColorContext::colorContext" type="IUnknown"/>-->

--- a/Source/SharpDX.Direct2D1/SharpDX.Direct2D1.csproj
+++ b/Source/SharpDX.Direct2D1/SharpDX.Direct2D1.csproj
@@ -24,6 +24,8 @@
     <Compile Include="CommandSink1.cs" />
     <Compile Include="CommandSink1Native.cs" />
     <Compile Include="CommandSink1Shadow.cs" />
+    <Compile Include="CommandSink2.cs" />
+    <Compile Include="CommandSink2Native.cs" />
     <Compile Include="ComputeInformation.cs" />
     <Compile Include="AnalysisTransform.cs" />
     <Compile Include="CommandSink.cs" />
@@ -34,6 +36,8 @@
     <Compile Include="ComputeTransformShadow.cs" />
     <Compile Include="D2D1.cs" />
     <Compile Include="Device1.cs" />
+    <Compile Include="Device2.cs" />
+    <Compile Include="DeviceContext2.cs" />
     <Compile Include="DeviceContext1.cs" />
     <Compile Include="DirectWrite\Factory1.cs" />
     <Compile Include="DirectWrite\LocalFontFileLoader.cs" />


### PR DESCRIPTION
Hello. I added mapping for direct2D1.3.
But I have a problem. 
```
in gccxml C:/Program Files (x86)/Windows Kits/10/Include/10.0.10240.0/um/d2d1_3.h:921: error: repeated using declaration 'using ID2D1Device::CreateDeviceContext'
in gccxml C:/Program Files (x86)/Windows Kits/10/Include/10.0.10240.0/um/d2d1_3.h:962: error: repeated using declaration 'using ID2D1Factory1::CreateDevice'
```
I temporarily comment out these lines in sdk.
I don't know how correct fix this error.
Help me, please.

Thanks