### PR TITLE
Make SharpDX LargeAddressAware compatible.

### DIFF
--- a/Source/SharpDX/Utilities.cs
+++ b/Source/SharpDX/Utilities.cs
@@ -474,7 +474,7 @@ namespace SharpDX
             var memPtr = Marshal.AllocHGlobal(sizeInBytes + mask + IntPtr.Size);
             var ptr = (long)((byte*)memPtr + sizeof(void*) + mask) & ~mask;
             ((IntPtr*)ptr)[-1] = memPtr;
-            return new IntPtr(ptr);
+            return new IntPtr((void*)ptr);
         }
 
         /// <summary>


### PR DESCRIPTION
For applications compiled as x86 and "LargeAddressAware", Marshal.AllocHGlobal() may return 32 bit IntPtr values >= 2^31 (negative). See: http://referencesource.microsoft.com/#mscorlib/system/runtime/interopservices/marshal.cs,363c3eb1c6f121df

Using IntPtr.IntPtr(long) with such a value results in an OverflowException due to the checked cast to int. See: http://referencesource.microsoft.com/#mscorlib/system/intptr.cs,349501d5fc6328c3

To test the problem, compile one of the SharpDX samples as x86 and use "editbin /LargeAddressAware" on the exe. The problem will show immediately, if you edit the registry (and reboot) as described here:
http://stackoverflow.com/questions/2288728/drawbacks-of-using-largeaddressaware-for-32-bit-windows-executables/22745579#22745579

This pull request fixes above issue and enables x86 SharpDX applications to use the LargeAddressAware flag. The only other usage of IntPtr.IntPtr(long) is SharpDX.PointerSize.PointerSize(long), but that's not too much of a problem. 