### PR TITLE
MessageFilterHook class is now public

### DIFF
--- a/Source/SharpDX.Desktop/MessageFilterHook.cs
+++ b/Source/SharpDX.Desktop/MessageFilterHook.cs
@@ -29,7 +29,7 @@ namespace SharpDX
     /// <summary>
     /// Provides a hook to WndProc of an existing window handle using <see cref="IMessageFilter"/>.
     /// </summary>
-    class MessageFilterHook
+    public class MessageFilterHook
     {
         #region Constants and Fields
 


### PR DESCRIPTION
MessageFilterHook made public, I've used it for different things (it used to be public in SharpDX 2.6.3).
Is there any reason to hide it?