### PR TITLE
ComObjectEventArgs is now struct

### DIFF
--- a/Source/SharpDX/Diagnostics/ObjectTracker.cs
+++ b/Source/SharpDX/Diagnostics/ObjectTracker.cs
@@ -31,7 +31,7 @@ namespace SharpDX.Diagnostics
     /// <summary>
     /// Event args for <see cref="ComObject"/> used by <see cref="ObjectTracker"/>.
     /// </summary>
-    public class ComObjectEventArgs : EventArgs
+    public struct ComObjectEventArgs
     {
         /// <summary>
         /// The object being tracked/untracked.


### PR DESCRIPTION
No need to allocate new object just to raise the event.

In some cases I'm calling native functions myself and then reusing managed objects (I just replace NativePointer and fix ref counts by calling Release/AddReference). It does not create any object on heap itself, but it internally raises ObjectTracker.Tracked, which creates object on heap...and that's annoying. Imho there's no reason to allocate new object on heap to raise event.