### PR TITLE
Fixed Issue #709 'XAudio2 SourceVoice.State.SamplesPlayed always returns 0 in 64-bit configurations'.

### DIFF
--- a/Source/SharpDX.XAudio2/Mapping-xaudio2.xml
+++ b/Source/SharpDX.XAudio2/Mapping-xaudio2.xml
@@ -217,6 +217,7 @@
     <map field="XAUDIO2FX_VOLUMEMETER_LEVELS::pRMSLevels" name="RmsLevelsPointer" />
     <map field="XAUDIO2FX_VOLUMEMETER_LEVELS::pRMSLevels" visibility="internal" />
     <map struct="XAUDIO2_EFFECT_DESCRIPTOR" native="true" struct-to-class="true" marshal="false" new="false" marshalto="true" />
+    <map struct="XAUDIO2_.*" pack="4" />
 
     <!--
     // *****************************************************************


### PR DESCRIPTION
Fixes #710 