### PR TITLE
Adding Direct3D11On12 Support in Direct3D11

### DIFF
--- a/Source/SharpDX.Direct3D11/Device.cs
+++ b/Source/SharpDX.Direct3D11/Device.cs
@@ -666,5 +666,14 @@ namespace SharpDX.Direct3D11
                 ImmediateContext__.Device__ = this;
             }
         }
+
+        public static Device CreateFromDirect3D12(ComObject d3d12Device, Direct3D11.DeviceCreationFlags flags, Direct3D.FeatureLevel[] featureLevels, DXGI.Adapter adapter, params ComObject[] commandQueues)
+        {
+            Device devOut;
+            DeviceContext contextOut;
+            Direct3D.FeatureLevel featurelevelOut;
+            D3D11.On12CreateDevice(d3d12Device, flags, featureLevels, featureLevels == null ? 0 : featureLevels.Length, commandQueues, commandQueues.Length, 0, out devOut, out contextOut, out featurelevelOut);
+            return devOut;
+        }
     }
 }

--- a/Source/SharpDX.Direct3D11/Mapping.xml
+++ b/Source/SharpDX.Direct3D11/Mapping.xml
@@ -42,6 +42,7 @@
   <include file="d3d11_2.h" attach="true" />
   <include file="d3d11_3.h" attach="true" />
   <include file="d3d11sdklayers.h" attach="true" />
+  <include file="d3d11on12.h" attach="true" />
 
   <naming />
 
@@ -49,6 +50,7 @@
     <context>sharpdx-direct3d11</context>
     <context>sharpdx-direct3d11-ext</context>
     <context>d3d11</context>
+    <context>d3d11on12</context>
     <context>d3d11sdklayers</context>
     <context>d3d11_1</context>
     <context>d3d11_2</context>
@@ -280,6 +282,10 @@
     
     <map param="ID3D11DeviceContext2::.*Tile.*::Flags" type="D3D11_TILE_MAPPING_FLAG" />
     <map param="ID3D11DeviceContext2::UpdateTileMappings::pRangeFlags" type="D3D11_TILE_RANGE_FLAG" />
+    
+    <map param="ID3D11On12Device::CreateWrappedResource::InState" type="int" />
+    <map param="ID3D11On12Device::CreateWrappedResource::OutState" type="int" />
+    <map param="ID3D11On12Device::CreateWrappedResource::ppResource11" type="ID3D11Resource" />
 
     <!--
     // *****************************************************************
@@ -292,6 +298,9 @@
     <map function="D3D11.*" dll='"d3d11.dll"' group="SharpDX.Direct3D11.D3D11" />
     <map param="D3D11CreateDevice::ppDevice" attribute="out fast" />
     <map function="D3D11CreateDevice" check="false"/>
+    <map function="D3D11On12CreateDevice" dll='"d3d11.dll"' group="SharpDX.Direct3D11.D3D11"/>
+    <map param="D3D11On12CreateDevice::Flags" type ="D3D11_CREATE_DEVICE_FLAG"/>
+    <map param="D3D11On12CreateDevice::ppDevice" type="ID3D11Device" attribute="out" />
     
     <remove function="ID3D11DeviceContext1_.*"/>
 

--- a/Source/SharpDX.Direct3D12/Mapping.xml
+++ b/Source/SharpDX.Direct3D12/Mapping.xml
@@ -316,7 +316,6 @@
     <remove function=".*_Proxy"/>
     <map function="D3D12(.+)" name-tmp="$1" />
     <map function="D3D12.*" dll='"d3d12.dll"' group="SharpDX.Direct3D12.D3D12" />
-    <map function="D3D11CreateDeviceForD3D12" dll='"d3d12.dll"' group="SharpDX.Direct3D12.D3D12" />
     <map param="D3D12CreateDevice::ppDevice" type="ID3D12Device" attribute="out fast" />
     <map function="D3D12CreateDevice" check="false"/>
     <map param="D3D12CreateDevice.*?::Flags" type="D3D12_CREATE_DEVICE_FLAG" />
@@ -327,9 +326,6 @@
     <map param="D3D12CreateDeviceAndSwapChain::ppSwapChain" type="IDXGISwapChain"/>
     <map param="D3D12CreateDeviceAndSwapChain::ppDevice" type="ID3D12Device"/>
 
-
-    <!-- Temporary remove d3d11 types -->
-    <remove function="D3D11CreateDeviceForD3D12"/>
 
     <!--
     // *****************************************************************


### PR DESCRIPTION
Added support for Direct3D11On12 in the Direct3D11 library as suggested by @xoofx . Removed the old mapping in Drect3d12 which was unused.

There does exist an unresolved problem, but I'm not sure what's causing it as the program just crashes. The code below always crashes with no error when I attempt to create a bitmap from a wrappedresource. This code is entirely based off of a directx12 sample. Just so you know this is an unresolved problem, and as I'm not getting any error feedback therefore I'm not sure what to make of it.

```C#
_fact2D = (new SharpDX.Direct2D1.Factory2(SharpDX.Direct2D1.FactoryType.MultiThreaded, SharpDX.Direct2D1.DebugLevel.Error)).QueryInterface<Factory2D>();
_dev11 = Device11.CreateFromDirect3D12(_dev, SharpDX.Direct3D11.DeviceCreationFlags.BgraSupport | SharpDX.Direct3D11.DeviceCreationFlags.Debug, null, _adapt, _queue);
// Query for the adapter and more advanced DXGI objects.
_dev11On12 = _dev11.QueryInterface<Device11On12>();
_devDXGI = _dev11On12.QueryInterface<SharpDX.DXGI.Device1>();

// Get the default Direct2D device and create a context.
_dev2D = new Device2D(_fact2D, _devDXGI);
_dev2DContext = new Device2DContext(_dev2D, SharpDX.Direct2D1.DeviceContextOptions.None);

_dev2DContext.PrimitiveBlend = SharpDX.Direct2D1.PrimitiveBlend.SourceOver;
_factWrite = new FactoryWrite(SharpDX.DirectWrite.FactoryType.Shared);

_properties = new BitmapProperties1(_format, _fact2D.DesktopDpi.Width, _fact2D.DesktopDpi.Width, SharpDX.Direct2D1.BitmapOptions.Target | SharpDX.Direct2D1.BitmapOptions.CannotDraw);

Surface _tempSurface;
for (int n = 0; n < FRAMECOUNT; n++)
{
        _rtv[n] = _chain.GetBackBuffer<Resource>(n);
        _dev.CreateRenderTargetView(_rtv[n], null, _cpuHandle);

        _dev11On12.CreateWrappedResource(_rtv[n], _resourceFlags, (int)ResourceStates.RenderTarget, (int)ResourceStates.Present, typeof(Resource11).GUID, out _wrappedBackBuffers[n]);
        _tempSurface = _wrappedBackBuffers[n].QueryInterface<Surface>();

        //Crashes on next line
        _targs[n] = new Bitmap1(_dev2DContext, _tempSurface, _properties);
        _cpuHandle += _rtvDescSize;
}
```