### PR TITLE
Fixed XAudio2.ProcessingPassStart event being invoked instead of ProcessingPassEnd.

### DIFF
--- a/Source/SharpDX.XAudio2/EngineShadow.cs
+++ b/Source/SharpDX.XAudio2/EngineShadow.cs
@@ -67,7 +67,7 @@ namespace SharpDX.XAudio2
             {
                 var shadow = ToShadow<EngineShadow>(thisObject);
                 var callback = (EngineCallback)shadow.Callback;
-                callback.OnProcessingPassStart();
+                callback.OnProcessingPassEnd();
             }
 
             /// <summary>	


### PR DESCRIPTION
SharpDX.XAudio2.EngineShadow.EngineVtbl.OnProcessingPassEndImpl was incorrectly calling callback.OnProcessingPassStart() instead of callback.OnProcessingPassEnd().