### PR TITLE
Update CustomDevice.cs

### DIFF
--- a/Source/SharpDX.DirectInput/CustomDevice.cs
+++ b/Source/SharpDX.DirectInput/CustomDevice.cs
@@ -106,6 +106,11 @@ namespace SharpDX.DirectInput
         {
             return GetObjectInfo(GetFromName(name).Offset, PropertyHowType.Byoffset);
         }
+        
+        public DeviceObjectInstance GetObjectInfoByOffset(int offset)
+        {
+            return GetObjectInfo(offset, PropertyHowType.Byoffset);
+        }
 
         public ObjectProperties GetObjectPropertiesByName(string name)
         {


### PR DESCRIPTION
Hi guys,

When a JoystickUpdate comes, the offset included there points to a field in the RawJoystickState struct. Sometimes, it's necessary to find what actual DeviceObjectInstance is related to that update.

For that, it would be necessary to clall GetObjectInfo(offset, PropertyHowType.Byoffset), but GetObjectByInfo is internal in your implementation. You already give access to some overloads of it with GetObjectInfoByName, GetObjectInfoById, and GetObjectInfoByUsage, but it lacks the last one: GetObjectInfoByOffset, which is crucial to do that mapping.

So, to achieve that, I have added the following method:

public DeviceObjectInstance GetObjectInfoByOffset(int offset)
{
return GetObjectInfo(offset, PropertyHowType.Byoffset);
}

Many thanks in advance, and congrats for your great great work.