### PR TITLE
Use "fixed" instead of StringToHGlobalUni

### DIFF
--- a/Source/Tools/SharpGen/Templates/Method.tt
+++ b/Source/Tools/SharpGen/Templates/Method.tt
@@ -225,13 +225,9 @@
 							}
 						}
 					// Handle Input String 
-					} else if (param.IsString) {
-						if (param.IsWideChar) {#>
-                IntPtr <#= param.TempName #> = Utilities.StringToHGlobalUni(<#= param.Name #>);
-<#+						} else {#>
+					} else if (param.IsString && !param.IsWideChar) {#>
                 IntPtr <#= param.TempName #> = Utilities.StringToHGlobalAnsi(<#= param.Name #>);
-<#+						}						
-					} else if ( param.IsRefIn && param.IsValueType && param.IsOptionnal) {#>
+<#+					} else if ( param.IsRefIn && param.IsValueType && param.IsOptionnal) {#>
                 <#= param.PublicType.QualifiedName #> <#= param.TempName #>;
                 if (<#= param.Name #>.HasValue)
                     <#= param.TempName #> = <#= param.Name #>.Value;				
@@ -272,7 +268,11 @@
 					} else if (param.IsFixed && param.IsValueType && !param.HasNativeValueType && !param.IsUsedAsReturnType) {#>
                 fixed (void* <#= param.TempName #> = &<#= param.Name #>)
 <#+						PushIndent("    ");
-					} 
+					// Handle Input String 
+					} else if (param.IsString && param.IsWideChar) {#>
+                fixed (char* <#= param.TempName #> = <#= param.Name #>)
+<#+						PushIndent("    ");
+					}						
 				}
 
 									
@@ -335,7 +335,7 @@
                 <#= param.Name #> = <#= param.TempName #> != 0;
 <#+						}						
 					// Handle Input String 
-					} else if (param.IsString) {#>
+					} else if (param.IsString && !param.IsWideChar) {#>
                 Marshal.FreeHGlobal(<#= param.TempName #> );
 <#+						
 					} else if (param.HasNativeValueType) {


### PR DESCRIPTION
This avoids many native allocations, esp. in BeginEvent/SetMarker (debug API) that might end up being called 1000+ times per frame in some scenario.

Note: Some optimizations could have been done to optimize StringToHGlobalAnsi as well (reuse decoding buffer to avoid allocation), but in practice this doesn't seem necessary since Ansi is used only for D3DCompiler and some other non-perf critical functions.