### PR TITLE
Added RawInputEventArgs.WindowHandle property

### DIFF
--- a/Source/SharpDX.RawInput/Device.cs
+++ b/Source/SharpDX.RawInput/Device.cs
@@ -141,10 +141,11 @@ namespace SharpDX.RawInput
         /// Handles a RawInput message manually.
         /// </summary>
         /// <param name="rawInputMessagePointer">A pointer to a RawInput message.</param>
+        /// <param name="hwnd">The handle of the window that received the RawInput message.</param>
         /// <remarks>
         /// This method can be used directly when handling RawInput messages from non-WinForms application.
         /// </remarks>
-        public static void HandleMessage(IntPtr rawInputMessagePointer)
+        public static void HandleMessage(IntPtr rawInputMessagePointer, IntPtr hwnd)
         {
             unsafe
             {
@@ -165,15 +166,15 @@ namespace SharpDX.RawInput
                 {
                     case DeviceType.HumanInputDevice:
                         if (RawInput != null)
-                            RawInput(null, new HidInputEventArgs(ref *rawInput));
+                            RawInput(null, new HidInputEventArgs(ref *rawInput, hwnd));
                         break;
                     case DeviceType.Keyboard:
                         if (KeyboardInput != null)
-                            KeyboardInput(null, new KeyboardInputEventArgs(ref *rawInput));
+                            KeyboardInput(null, new KeyboardInputEventArgs(ref *rawInput, hwnd));
                         break;
                     case DeviceType.Mouse:
                         if (MouseInput != null)
-                            MouseInput(null, new MouseInputEventArgs(ref *rawInput));
+                            MouseInput(null, new MouseInputEventArgs(ref *rawInput, hwnd));
                         break;
                 }
             }
@@ -193,7 +194,7 @@ namespace SharpDX.RawInput
             {
                 // Handle only WM_INPUT messages
                 if (m.Msg == WmInput)
-                    HandleMessage(m.LParam);
+                    HandleMessage(m.LParam, m.HWnd);
                 return false;
             }
         }

--- a/Source/SharpDX.RawInput/HidInputEventArgs.cs
+++ b/Source/SharpDX.RawInput/HidInputEventArgs.cs
@@ -38,7 +38,8 @@ namespace SharpDX.RawInput
         /// Initializes a new instance of the <see cref="HidInputEventArgs"/> class.
         /// </summary>
         /// <param name="rawInput">The raw input.</param>
-        internal HidInputEventArgs(ref RawInput rawInput) : base(ref rawInput)
+        /// <param name="hwnd">The handle of the window that received the RawInput mesage.</param>
+        internal HidInputEventArgs(ref RawInput rawInput, IntPtr hwnd) : base(ref rawInput, hwnd)
         {
             Count = rawInput.Data.Hid.Count;
             DataSize = rawInput.Data.Hid.SizeHid;

--- a/Source/SharpDX.RawInput/KeyboardInputEventArgs.cs
+++ b/Source/SharpDX.RawInput/KeyboardInputEventArgs.cs
@@ -17,6 +17,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
+using System;
 using System.Windows.Forms;
 
 namespace SharpDX.RawInput
@@ -37,8 +39,9 @@ namespace SharpDX.RawInput
         /// Initializes a new instance of the <see cref="KeyboardInputEventArgs"/> class.
         /// </summary>
         /// <param name="rawInput">The raw input.</param>
-        internal KeyboardInputEventArgs(ref RawInput rawInput)
-            : base(ref rawInput)
+        /// <param name="hwnd">The handle of the window that received the RawInput mesage.</param>
+        internal KeyboardInputEventArgs(ref RawInput rawInput, IntPtr hwnd)
+            : base(ref rawInput, hwnd)
         {
             Key = (Keys) rawInput.Data.Keyboard.VKey;
             MakeCode = rawInput.Data.Keyboard.MakeCode;

--- a/Source/SharpDX.RawInput/MouseInputEventArgs.cs
+++ b/Source/SharpDX.RawInput/MouseInputEventArgs.cs
@@ -17,6 +17,9 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
+using System;
+
 namespace SharpDX.RawInput
 {
     /// <summary>
@@ -35,8 +38,9 @@ namespace SharpDX.RawInput
         /// Initializes a new instance of the <see cref="MouseInputEventArgs"/> class.
         /// </summary>
         /// <param name="rawInput">The raw input.</param>
-        internal MouseInputEventArgs(ref RawInput rawInput)
-            : base(ref rawInput)
+        /// <param name="hwnd">The handle of the window that received the RawInput mesage.</param>
+        internal MouseInputEventArgs(ref RawInput rawInput, IntPtr hwnd)
+            : base(ref rawInput, hwnd)
         {
             Mode = (MouseMode) rawInput.Data.Mouse.Flags;
             ButtonFlags = (MouseButtonFlags)rawInput.Data.Mouse.ButtonsData.ButtonFlags;

--- a/Source/SharpDX.RawInput/RawInputEventArgs.cs
+++ b/Source/SharpDX.RawInput/RawInputEventArgs.cs
@@ -30,9 +30,10 @@ namespace SharpDX.RawInput
         {
         }
 
-        internal RawInputEventArgs(ref RawInput rawInput)
+        internal RawInputEventArgs(ref RawInput rawInput, IntPtr hwnd)
         {
             Device = rawInput.Header.Device;
+	        WindowHandle = hwnd;
         }
 
         /// <summary>
@@ -42,5 +43,13 @@ namespace SharpDX.RawInput
         /// The device.
         /// </value>
         public IntPtr Device { get; set; }
+
+        /// <summary>
+        /// Gets or sets the handle of the window that received the RawInput mesage.
+        /// </summary>
+        /// <value>
+        /// The window handle.
+        /// </value>
+        public IntPtr WindowHandle { get; set; }
     }
 }


### PR DESCRIPTION
RawInputEventArgs (and thus also HidInputEventArgs, KeyboardInputEventArgs, and MouseInputEventArgs) now has a WindowHandle property that can be used to retrieve the handle of the window that received the raw input event.