### PR TITLE
Better naming for ID3D11On12Device to reflect SharpDX.

### DIFF
--- a/Source/SharpDX.Direct3D11/Mapping.xml
+++ b/Source/SharpDX.Direct3D11/Mapping.xml
@@ -257,6 +257,8 @@
 
     <map interface="ID3DDeviceContextState" name="DeviceContextState"/>
     <map interface="ID3DUserDefinedAnnotation" name="UserDefinedAnnotation"/>
+    <map interface="ID3D11On12Device" name="Device11On12"/>
+    
     <map method="ID3DUserDefinedAnnotation::SetMarker" property="false" />
 
     <map param="ID3D11Device1::CreateDeviceContextState::Flags" type="D3D11_1_CREATE_DEVICE_CONTEXT_STATE_FLAG"/>


### PR DESCRIPTION
Improve ID3D11On12Device generation to be Device11On12 for better naming convention.