### PR TITLE
Fix button array bug in Update MouseState.cs

### DIFF
--- a/Source/SharpDX.DirectInput/MouseState.cs
+++ b/Source/SharpDX.DirectInput/MouseState.cs
@@ -52,7 +52,11 @@ namespace SharpDX.DirectInput
                 Z = value.Z;
 
                 // Copy buttons states
-                fixed (void* __to = &Buttons[0]) fixed (void* __from = &value.Buttons0) SharpDX.Utilities.CopyMemory((IntPtr)__to, (IntPtr)__from, Buttons.Length);
+                fixed(void* __from = &value.Buttons0) {
+                    for(int i = 0; i < 8; i++) {
+                        Buttons[i] = (((byte*)__from)[i] & 0x80) != 0;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Fixed incorrect direct copying of returned button array bytes into C# Boolean array. According to this page, https://msdn.microsoft.com/en-us/library/windows/desktop/bb151897(v=vs.85).aspx, the data format states that the value of the byte will be 128 if the button is on and 0 if the button is off. By directly copying the byte value of 128 into a bool, an invalid Boolean is created which initially doesn't cause any problems, but will fail if you bitwise or the bool with true giving you a value of 129 which evaluates to false when compared to C# true (1). This error also existed in JoystickState in a past version and was fixed. The same error in MouseState was never fixed however.