### PR TITLE
Fix: Memory leak for D3D11 device when `CreateWithSwapChain` is used

### DIFF
--- a/Source/SharpDX.Direct3D11/Device.cs
+++ b/Source/SharpDX.Direct3D11/Device.cs
@@ -190,15 +190,6 @@ namespace SharpDX.Direct3D11
             {
                 swapChain = new SwapChain(factory, device, swapChainDescription);
             }
-
-            var context = device.ImmediateContext;
-
-            if (context != null)
-            {
-                context.Device__ = device;
-            }
-
-            device.ImmediateContext__ = context;
         }
 
         /// <summary>


### PR DESCRIPTION
When `CreateWithSwapChain` method is used to create a device, it ends up in a native memory leak, when the device, and all its devices are disposed. This doesn't happen when the device and swap chains are created manually. 

Turns out, this happens due to the extra `AddRefs` that gets called internally. The extra unmanaged memory that ends up leaking can be worked around by casting to `IUnknown` and doing an extra manual release, on the device context. 

Incidentally, it happens to be so that the entire set of code that causes this leak in the first place, is totally redundant, since the `ImmediateContext` and the inner `Device` that are manually force initialized care of themselves already. So, simply removing the unnecessary code fixes this. 

PS: Is there any reason that this code is here in the first place? Hopefully, its just there due to legacy reasons, and I didn't miss something important.