### PR TITLE
Add missing DirectComposition method to create Target from `Device`

### DIFF
--- a/Source/SharpDX.DirectComposition/Target.cs
+++ b/Source/SharpDX.DirectComposition/Target.cs
@@ -18,5 +18,17 @@ namespace SharpDX.DirectComposition
 		{
 			return desktopDevice.CreateTargetForHwnd(hwnd, topmost);
 		}
+        
+        /// <summary>
+		/// Creates a composition target object that is bound to the window that is represented by the specified window handle.
+		/// </summary>
+		/// <param name="device">A device the target is to be associated with.</param>
+		/// <param name="hwnd">The window to which the composition object will be bound. This cannot be null.</param>
+		/// <param name="topmost">TRUE if the visual tree should be displayed on top of the children of the window specified by the hwnd parameter; otherwise, the visual tree is displayed behind the children.</param>
+		/// <returns></returns>
+		public static Target FromHwnd(Device device, IntPtr hwnd, bool topmost)
+		{
+			return device.CreateTargetForHwnd(hwnd, topmost);
+		}
 	}
 }

--- a/Source/SharpDX.DirectComposition/Target.cs
+++ b/Source/SharpDX.DirectComposition/Target.cs
@@ -26,9 +26,11 @@ namespace SharpDX.DirectComposition
 		/// <param name="hwnd">The window to which the composition object will be bound. This cannot be null.</param>
 		/// <param name="topmost">TRUE if the visual tree should be displayed on top of the children of the window specified by the hwnd parameter; otherwise, the visual tree is displayed behind the children.</param>
 		/// <returns></returns>
-		public static Target FromHwnd(Device device, IntPtr hwnd, bool topmost)
-		{
-			return device.CreateTargetForHwnd(hwnd, topmost);
-		}
+      public static Target FromHwnd(Device device, IntPtr hwnd, bool topmost)
+      {
+         Target target;
+         device.CreateTargetForHwnd(hwnd, topmost, out target);
+         return target;
+      }
 	}
 }


### PR DESCRIPTION
This is method is the only way to create a Target in Windows 8, which doesn't have `DesktopDevice`. And this method is unfortunately missing.