### PR TITLE
The SharpDX commit b9f7519 caused the .NET Native compiler to crash.

### DIFF
--- a/Source/SharpDX/DataBuffer.cs
+++ b/Source/SharpDX/DataBuffer.cs
@@ -59,16 +59,17 @@ namespace SharpDX
                 DataBuffer buffer;
 
                 var sizeOfBuffer = Utilities.SizeOf(userBuffer);
+                var indexOffset = index * Utilities.SizeOf<T>();
 
                 if (pinBuffer)
                 {
                     var handle = GCHandle.Alloc(userBuffer, GCHandleType.Pinned);
-                    var indexOffset = index * Utilities.SizeOf<T>();
                     buffer = new DataBuffer(indexOffset + (byte*)handle.AddrOfPinnedObject(), sizeOfBuffer - indexOffset, handle);
                 }
                 else
                 {
-                    buffer = new DataBuffer(Interop.Fixed(userBuffer), sizeOfBuffer, true);
+                    // The .NET Native compiler crashes if '(IntPtr)' is removed.
+                    buffer = new DataBuffer(indexOffset + (byte *)(IntPtr)Interop.Fixed(userBuffer), sizeOfBuffer - indexOffset, true);
                 }
 
                 return buffer;

--- a/Source/SharpDX/DataStream.cs
+++ b/Source/SharpDX/DataStream.cs
@@ -115,7 +115,8 @@ namespace SharpDX
                 }
                 else
                 {
-                    stream = new DataStream(indexOffset + (byte*)Interop.Fixed(userBuffer), sizeOfBuffer - indexOffset, canRead, canWrite, true);
+                    // The .NET Native compiler crashes if '(IntPtr)' is removed.
+                    stream = new DataStream(indexOffset + (byte*)(IntPtr)Interop.Fixed(userBuffer), sizeOfBuffer - indexOffset, canRead, canWrite, true);
                 }
 
                 return stream;


### PR DESCRIPTION
This change works around the .NET Native compiler bug by casting to (IntPtr).

I also noticed that DataBuffer had the same issue as DataStream which was fixed by b9f7519 so I applied the same fix to DataBuffer.

FWIW the code in question calls Interop.Fixed which throws NotImplementedException.