### PR TITLE
Fixed WicStream.Dispose bug exposed by .NET Native

### DIFF
--- a/Source/SharpDX.Direct2D1/WIC/WICStream.cs
+++ b/Source/SharpDX.Direct2D1/WIC/WICStream.cs
@@ -79,13 +79,13 @@ namespace SharpDX.WIC
 
         protected override void Dispose(bool disposing)
         {
+            base.Dispose(disposing);
+
             if (streamProxy != null)
             {
                 streamProxy.Dispose();
                 streamProxy = null;
             }
-
-            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
Fixed WicStream.Dispose to dispose of 'streamProxy' after calling base.Dispose to fix a crash in .NET Native when used with a MemoryStream in a multi-threaded image rendering test.

This change makes WicStream consistent with the behavior of SharpDX.MediaFoundation.ByteStream.