### PR TITLE
Fixed AdapterDescription.Description text with fixing PtrToStringAnsi and PtrToStringUni methods

### DIFF
--- a/Source/SharpDX/Utilities.cs
+++ b/Source/SharpDX/Utilities.cs
@@ -502,7 +502,11 @@ namespace SharpDX
         /// <returns>The converted string.</returns>
         public static string PtrToStringAnsi(IntPtr pointer, int maxLength)
         {
-            return Marshal.PtrToStringAnsi(pointer, maxLength);
+            string managedString = Marshal.PtrToStringAnsi(pointer); // copy null-terminating unmanaged text from pointer to a managed string
+            if (managedString != null && managedString.Length > maxLength)
+                managedString = managedString.Substring(0, maxLength);
+
+            return managedString;
         }
 
         /// <summary>
@@ -513,10 +517,14 @@ namespace SharpDX
         /// <returns>The converted string.</returns>
         public static string PtrToStringUni(IntPtr pointer, int maxLength)
         {
-            return Marshal.PtrToStringUni(pointer, maxLength);
+            string managedString = Marshal.PtrToStringUni(pointer); // copy null-terminating unmanaged text from pointer to a managed string
+            if (managedString != null && managedString.Length > maxLength)
+                managedString = managedString.Substring(0, maxLength);
+
+            return managedString;
         }
 
-    /// <summary>
+        /// <summary>
         /// Copies the contents of a managed String into unmanaged memory, converting into ANSI format as it copies.
         /// </summary>
         /// <param name="s">A managed string to be copied.</param> 


### PR DESCRIPTION
This is a fix for issues https://github.com/sharpdx/SharpDX/issues/828 and https://github.com/sharpdx/SharpDX/issues/806

The existing code used Marshal.PtrToStringUni(pointer, maxLength) method that did not terminate the string at first null char - see MSDN: https://msdn.microsoft.com/en-us/library/k4x4bfws(v=vs.110).aspx

This resulted in having Adapter description always 128 chars long.

The proposed fix uses Marshal.PtrToStringUni(pointer) method (without maxLength parameter) that correctly terminates the string - see MSDN: https://msdn.microsoft.com/en-us/library/dyf0tzy4(v=vs.110).aspx

The fixed code also truncates the string if it is larger than the specified maxLength.