### PR TITLE
RectangleF.Contains(Vector2) now includes right and lower border

### DIFF
--- a/Source/SharpDX.Mathematics/RectangleF.cs
+++ b/Source/SharpDX.Mathematics/RectangleF.cs
@@ -276,7 +276,7 @@ namespace SharpDX
         /// <param name="result">[OutAttribute] true if the specified Point is contained within this rectangle; false otherwise.</param>
         public void Contains(ref Vector2 value, out bool result)
         {
-            result = (X <= value.X) && (value.X < Right) && (Y <= value.Y) && (value.Y < Bottom);
+            result = (value.X >= Left && value.X <= Right && value.Y >= Top && value.Y <= Bottom);
         }
 
         /// <summary>Determines whether this rectangle entirely contains a specified rectangle.</summary>


### PR DESCRIPTION
Containment method for Vector2 of RectangleF is now exactly the same as for individual x and y values. for some reason it was excluding the right and lower border.