### PR TITLE
Freeing allocated string in DebugName setter

### DIFF
--- a/Source/SharpDX.Direct3D10/DeviceChild.cs
+++ b/Source/SharpDX.Direct3D10/DeviceChild.cs
@@ -58,6 +58,7 @@ namespace SharpDX.Direct3D10
                 {
                     var namePtr = Marshal.StringToHGlobalAnsi(value);
                     SetPrivateData(CommonGuid.DebugObjectName, value.Length, namePtr);
+                    Marshal.FreeHGlobal(namePtr);
                 }
             }
         }        

--- a/Source/SharpDX.Direct3D11/DeviceChild.cs
+++ b/Source/SharpDX.Direct3D11/DeviceChild.cs
@@ -58,6 +58,7 @@ namespace SharpDX.Direct3D11
                 {
                     var namePtr = Utilities.StringToHGlobalAnsi(value);
                     SetPrivateData(CommonGuid.DebugObjectName, value.Length, namePtr);
+                    Marshal.FreeHGlobal(namePtr);
                 }
             }
         }


### PR DESCRIPTION
This is a fix for Issue  #850.

Because portable .Net does not provide methods to convert string into ANSI encoded byte array (as proposed by OndrejPetrzilka), the solution is to continue using Marshal.StringToHGlobalAnsi and releasing it with  #Marshal.FreeHGlobal.
