### PR TITLE
Updated variant.cs for issue #787

### DIFF
--- a/Source/SharpDX/Win32/Variant.cs
+++ b/Source/SharpDX/Win32/Variant.cs
@@ -275,6 +275,20 @@ namespace SharpDX.Win32
                 Type = VariantType.Default;
                 if (type.GetTypeInfo().IsPrimitive)
                 {
+					if (type == typeof(byte))
+					{
+						ElementType = VariantElementType.UByte;
+						variantValue.byteValue = (byte)value;
+						return;
+					}
+
+	                if (type == typeof(sbyte))
+	                {
+		                ElementType = VariantElementType.Byte;
+		                variantValue.signedByteValue = (sbyte)value;
+		                return;
+	                }
+
                     if (type == typeof(int))
                     {
                         ElementType = VariantElementType.Int;


### PR DESCRIPTION
Added setter functionality to assign byte and sbyte values to a variant
type. This will correct the issue described in issue #787