### PR TITLE
Fix sharpdx.DirectComposition project metadata.

### DIFF
--- a/Source/SharpDX.DirectComposition/SharpDX.DirectComposition.csproj
+++ b/Source/SharpDX.DirectComposition/SharpDX.DirectComposition.csproj
@@ -2,12 +2,12 @@
   <Import Project="..\..\Build\SharpDX.props" />
   <PropertyGroup>
     <TargetFrameworks>net45;netcoreapp1.0;netstandard1.3</TargetFrameworks>
-    <PackageId>SharpDX.Direct3D9</PackageId>
-    <Product>SharpDX.Direct3D9</Product>
-    <AssemblyTitle>SharpDX.Direct3D9</AssemblyTitle>
-    <Title>SharpDX.Direct3D9</Title>
-    <Description>Assembly providing DirectX - Direct3D9 managed API.</Description>
-    <PackageTags>$(PackageTags) Direct3D9 D3D9</PackageTags>
+    <PackageId>SharpDX.DirectComposition</PackageId>
+    <Product>SharpDX.DirectComposition</Product>
+    <AssemblyTitle>SharpDX.DirectComposition</AssemblyTitle>
+    <Title>SharpDX.DirectComposition</Title>
+    <Description>Assembly providing DirectX - DirectComposition managed API.</Description>
+    <PackageTags>$(PackageTags) DirectComposition DComposition</PackageTags>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' OR  '$(TargetFramework)' == 'netcoreapp1.0' ">
     <DefineConstants>$(DefineConstants);DESKTOP_APP</DefineConstants>


### PR DESCRIPTION
Correctly generate the SharpDX.DirectComposition package and don't overwrite the SharpDX.Direct3D9 package.

Fix #873 