### PR TITLE
Remove Windows 10 SDK requirement from the SharpGen batch script

### DIFF
--- a/Source/Tools/SharpGen/RunGenerator.bat
+++ b/Source/Tools/SharpGen/RunGenerator.bat
@@ -7,7 +7,7 @@ xcopy /D /Y "%~dp0MSDNDoc.zip" .
 
 REM Find a VS 2017 installation with the C++ toolset installed.
 set InstallDir=
-for /f "usebackq tokens=*" %%i in (`..\..\..\..\..\External\vswhere\vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 Microsoft.VisualStudio.Component.Windows10SDK.14393 -property installationPath`) do (
+for /f "usebackq tokens=*" %%i in (`..\..\..\..\..\External\vswhere\vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
   set InstallDir=%%i
 )
 set ToolsVersion=


### PR DESCRIPTION
Fixes the issue in #888.