### PR TITLE
DirectWrite enhancements

### DIFF
--- a/Source/SharpDX.Direct2D1/DirectWrite/FontFallback.cs
+++ b/Source/SharpDX.Direct2D1/DirectWrite/FontFallback.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) 2010-2013 SharpDX - Alexandre Mutel
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SharpDX.DirectWrite
+{
+    public partial class FontFallback
+    {
+        /// <summary>
+        /// <p>Determines an appropriate font to use to render the beginning range of text.</p>
+        /// </summary>
+        /// <param name="analysisSource"><dd>  <p>The text source implementation holds the text and locale.</p> </dd></param>
+        /// <param name="textPosition"><dd>  <p>Starting position to analyze.</p> </dd></param>
+        /// <param name="textLength"><dd>  <p>Length of the text to analyze.</p> </dd></param>
+        /// <param name="baseFontCollection"><dd>  <p>Default font collection to use.</p> </dd></param>
+        /// <param name="baseFamilyName"><dd>  <p>Family name of the base font. If you pass null, no matching     will be done against the family.</p> </dd></param>
+        /// <param name="baseWeight"><dd>  <p>The desired weight.</p> </dd></param>
+        /// <param name="baseStyle"><dd>  <p>The desired style.</p> </dd></param>
+        /// <param name="baseStretch"><dd>  <p>The desired stretch.</p> </dd></param>
+        /// <param name="mappedLength"><dd>  <p>Length of text mapped to the mapped font. This will always be less than     or equal to the text length and greater than zero (if the text length is non-zero) so     the caller advances at least one character.</p> </dd></param>
+        /// <param name="mappedFont"><dd>  <p>The font that should be used to render the first <em>mappedLength</em> characters of the text. If it returns <c>null</c>, that means that no font can render the     text, and <em>mappedLength</em> is the number of characters to skip (rendered with a missing glyph).</p> </dd></param>
+        /// <param name="scale"><dd>  <p>Scale factor to multiply the em size of the returned font by.</p> </dd></param>
+        public void MapCharacters(
+            TextAnalysisSource analysisSource,
+            int textPosition,
+            int textLength,
+            FontCollection baseFontCollection,
+            string baseFamilyName,
+            FontWeight baseWeight,
+            FontStyle baseStyle,
+            FontStretch baseStretch,
+            out int mappedLength,
+            out Font mappedFont,
+            out float scale
+        )
+        {
+            MapCharacters_(
+                TextAnalysisSourceShadow.ToIntPtr(analysisSource),
+                textPosition,
+                textLength,
+                baseFontCollection,
+                baseFamilyName,
+                baseWeight,
+                baseStyle,
+                baseStretch,
+                out mappedLength,
+                out mappedFont,
+                out scale
+            );
+        }
+    }
+}

--- a/Source/SharpDX.Direct2D1/DirectWrite/Mapping.xml
+++ b/Source/SharpDX.Direct2D1/DirectWrite/Mapping.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
 // Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,14 +26,14 @@
 
   <namespace>SharpDX.DirectWrite</namespace>
   <assembly>SharpDX.Direct2D1</assembly>
-  
+
   <include file="dwrite.h" attach="true" output="DirectWrite"/>
   <include file="dwrite_1.h" attach="true" output="DirectWrite"/>
   <include file="dwrite_2.h" attach="true" output="DirectWrite"/>
   <include file="dwrite_3.h" attach="true" output="DirectWrite"/>
 
   <naming />
-  
+
   <extension>
     <create class="DWrite" />
   </extension>
@@ -124,7 +124,7 @@
 
     <map param="IDWriteFont::HasCharacter::exists" return="true" />
     <map param="IDWriteFont::GetInformationalStrings::exists" return="true" />
-    
+
     <map method="IDWriteFontFace::GetFiles" visibility="internal" />
     <map method="IDWriteFontFace::GetDesignGlyphMetrics" visibility="internal" />
     <map method="IDWriteFontFace::GetGdiCompatibleGlyphMetrics" visibility="internal" />
@@ -133,6 +133,9 @@
     <map param="IDWriteFontFace::GetRecommendedRenderingMode::renderingMode" return="true" />
     <map method="IDWriteFontFace::TryGetFontTable" visibility="internal" />
     <map method="IDWriteFontFace::GetType" name="GetFaceType" />
+
+    <map param="IDWriteFontFallback::MapCharacters::mappedLength" attribute="out" />
+
     <map param="IDWriteFontList::GetFont::font" return="true" />
     <map param="IDWriteFontFamily::GetFirstMatchingFont::matchingFont" return="true" />
     <map param="IDWriteFontFamily::GetMatchingFonts::matchingFonts" return="true" />
@@ -141,7 +144,7 @@
     <map param="IDWriteFontCollection::GetFontFromFontFace::font" return="true" />
     <map interface="IDWriteFontCollectionLoader" callback="true" callback-dual="false" />
     <map method="IDWriteFontFile::GetLoader" visibility="internal" property="false" />
-    
+
     <map interface="IDWriteFontFileLoader" callback-visibility="public" callback="true" callback-dual="true" />
 
     <map interface="IDWriteFontFileEnumerator" callback="true" callback-dual="false" />
@@ -152,7 +155,7 @@
     <map param="logFont" type="void" attribute="in" />
     <map param="IDWriteGdiInterop::CreateBitmapRenderTarget::renderTarget" return="true" />
     <map param="IDWriteGdiInterop::CreateFontFaceFromHdc::fontFace" return="true" />
-      
+
     <map method="IDWriteGdiInterop1::.*?LOGFONT" visibility="internal" />
     <map param="logFont" type="void" attribute="in" />
     <map param="IDWriteGdiInterop1::CreateBitmapRenderTarget::renderTarget" return="true" />
@@ -208,14 +211,14 @@
     <map method="IDWriteTextLayout::GetLineMetrics" check="false"/>
     <map method="IDWriteTextLayout::HitTestTextRange" check="false"/>
     <map method="IDWriteTextLayout::GetClusterMetrics" check="false"/>
-    
+
     <map method="IDWriteLocalFontFileLoader::GetFilePath.*" visibility="internal"/>
     <map method="IDWriteLocalFontFileLoader::GetLastWriteTimeFromKey" visibility="internal"/>
 
     <map method="IDWriteBitmapRenderTarget::DrawGlyphRun" visibility="private"/>
     <map param="IDWriteBitmapRenderTarget::DrawGlyphRun::textColor" type="int"/>
-     
-     
+
+
     <map param="IDWriteRemoteFontFileStream::BeginDownload::asyncResult" return="true" />
     <map method="IDWriteAsyncResult::GetResult" check="false"/>
 

--- a/Source/Tools/SharpGen/CppModel/CppStruct.cs
+++ b/Source/Tools/SharpGen/CppModel/CppStruct.cs
@@ -36,6 +36,13 @@ namespace SharpGen.CppModel
         public int Align { get; set; }
 
         /// <summary>
+        /// Gets or sets the name of the parent.
+        /// </summary>
+        /// <value>The name of the parent.</value>
+        [XmlAttribute("base")]
+        public string ParentName { get; set; }
+
+        /// <summary>
         /// Gets the fields.
         /// </summary>
         /// <value>The fields.</value>


### PR DESCRIPTION
From what we discussed in https://github.com/sharpdx/SharpDX/issues/896.

There are DirectWrite structs, such as [FontFallback1](https://msdn.microsoft.com/en-us/library/windows/desktop/jj126259(v=vs.85).aspx), that have ancestor structs, but the latter's fields were not written out for the former so we were seeing `AccessViolationException`s. https://github.com/sharpdx/SharpDX/commit/1ab7aa929e2e57c3b543f8b8d0ad790d5d3e607d should fix that.

https://github.com/sharpdx/SharpDX/commit/18cb55ae57df46adf84a1bf22548220f24493f96 provides a public wrapper for a method on DirectWrite's `FontFallback`.