### PR TITLE
Improve error reporting in ShaderBytecode.Compile/CompileFromFile

### DIFF
--- a/Source/SharpDX.D3DCompiler/ShaderBytecode.cs
+++ b/Source/SharpDX.D3DCompiler/ShaderBytecode.cs
@@ -363,40 +363,35 @@ namespace SharpDX.D3DCompiler
                 if (!(profile.ToUpperInvariant().StartsWith("FX_") || profile.ToUpperInvariant().StartsWith("LIB_")) && string.IsNullOrWhiteSpace(entryPoint))
                     throw new ArgumentNullException("entryPoint");
 
-                var resultCode = Result.Ok;
-
                 Blob blobForCode = null;
                 Blob blobForErrors = null;
 
-                try
-                {
-                    D3D.Compile2(
-                        (IntPtr)textSource,
-                        textSize,
-                        sourceFileName,
-                        PrepareMacros(defines),
-                        IncludeShadow.ToIntPtr(include),
-                        entryPoint,
-                        profile,
-                        shaderFlags,
-                        effectFlags,
-                        secondaryDataFlags,
-                        secondaryData != null ? secondaryData.DataPointer : IntPtr.Zero,
-                        secondaryData != null ? (int)secondaryData.Length : 0,
-                        out blobForCode,
-                        out blobForErrors);
-                }
-                catch (SharpDXException ex)
+                var resultCode = D3D.Compile2(
+                    (IntPtr)textSource,
+                    textSize,
+                    sourceFileName,
+                    PrepareMacros(defines),
+                    IncludeShadow.ToIntPtr(include),
+                    entryPoint,
+                    profile,
+                    shaderFlags,
+                    effectFlags,
+                    secondaryDataFlags,
+                    secondaryData != null ? secondaryData.DataPointer : IntPtr.Zero,
+                    secondaryData != null ? (int)secondaryData.Length : 0,
+                    out blobForCode,
+                    out blobForErrors);
+
+                if (resultCode.Failure)
                 {
                     if (blobForErrors != null)
                     {
-                        resultCode = ex.ResultCode;
                         if (Configuration.ThrowOnShaderCompileError)
-                            throw new CompilationException(ex.ResultCode, Utilities.BlobToString(blobForErrors));
+                            throw new CompilationException(resultCode, Utilities.BlobToString(blobForErrors));
                     }
                     else
                     {
-                        throw;
+                        throw new SharpDXException(resultCode);
                     }
                 }
 

--- a/Source/SharpDX.D3DCompiler/ShaderBytecode.cs
+++ b/Source/SharpDX.D3DCompiler/ShaderBytecode.cs
@@ -475,7 +475,7 @@ namespace SharpDX.D3DCompiler
             ShaderMacro[] defines = null,
             Include include = null)
         {
-            return Compile(NativeFile.ReadAllText(fileName), entryPoint, profile, shaderFlags, effectFlags, defines, include);
+            return Compile(NativeFile.ReadAllText(fileName), entryPoint, profile, shaderFlags, effectFlags, defines, include, fileName);
         }
 
         // Win 8.1 SDK removed the corresponding functions from the WinRT platform


### PR DESCRIPTION
This PR addresses two issues related to compiling ShaderBytecode:

* When `ShaderBytecode.Compile` failed, it never returned an error result code or threw an exception, even when `Configuration.ThrowOnShaderCompileError` was `true`. This is because it assumed that `D3D.Compile2` throws an exception on failure, which is not the case. This PR adds explicit error handling by checking the result code. This fixes #695.
* When using `ShaderBytecode.CompileFromFile`, the error messages always refer to the source file as `unknown`. Passing along the `fileName` fixes this.