### PR TITLE
fixed binding redirects in SharpPak

### DIFF
--- a/Source/Tools/SharpPak/SharpPak.csproj
+++ b/Source/Tools/SharpPak/SharpPak.csproj
@@ -12,6 +12,7 @@
     <AssemblyName>SharpPak</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
   </PropertyGroup>


### PR DESCRIPTION
without the fix, SharpPak crashes because it can't load the correct version of Mono.Cecil (it uses both 9.5.0 and 9.6.0)