### PR TITLE
D3D11 DeviceContext Dispose fix

### DIFF
--- a/Source/SharpDX.Direct3D11/DeviceContext.cs
+++ b/Source/SharpDX.Direct3D11/DeviceContext.cs
@@ -607,18 +607,5 @@ namespace SharpDX.Direct3D11
 
         private bool isCheckThreadingSupport;
         private bool supportsCommandLists;
-
-        /// <inheritdoc/>
-        protected override unsafe void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                // When disposing an DeviceContext, performs a ClearState/Flush before.
-                ClearState();
-                Flush();
-            }
-
-            base.Dispose(disposing);
-        }
     }
 }


### PR DESCRIPTION
Avoid calling ClearState and Flush during D3D11 DeviceContext Dispose.
Fixes #929