### PR TITLE
Update Mapping.xml - fix GamepadButtonFlags

### DIFF
--- a/Source/SharpDX.XInput/Mapping.xml
+++ b/Source/SharpDX.XInput/Mapping.xml
@@ -94,7 +94,7 @@
     <map enum="XINPUT_CAPS_FLAGS" name="CapabilityFlags" type="short"/>
     <map enum-item="XINPUT_CAPS_(.*)" name-tmp="$1"/>
 
-    <map enum="XINPUT_GAMEPAD_BUTTON_FLAGS" name="GamepadButtonFlags" flags="true" none="true" type="short"/>
+    <map enum="XINPUT_GAMEPAD_BUTTON_FLAGS" name="GamepadButtonFlags" flags="true" none="true" type="ushort"/>
     <map enum-item="XINPUT_GAMEPAD_(.*)" name-tmp="$1"/>
     <map enum-item="XINPUT_GAMEPAD_DPAD_(.*)" name-tmp="D_PAD_$1"/>
 

--- a/Source/SharpDX.XInput/Mapping.xml
+++ b/Source/SharpDX.XInput/Mapping.xml
@@ -94,7 +94,7 @@
     <map enum="XINPUT_CAPS_FLAGS" name="CapabilityFlags" type="short"/>
     <map enum-item="XINPUT_CAPS_(.*)" name-tmp="$1"/>
 
-    <map enum="XINPUT_GAMEPAD_BUTTON_FLAGS" name="GamepadButtonFlags" flags="true" none="true" type="ushort"/>
+    <map enum="XINPUT_GAMEPAD_BUTTON_FLAGS" name="GamepadButtonFlags" flags="true" none="true" type="int"/>
     <map enum-item="XINPUT_GAMEPAD_(.*)" name-tmp="$1"/>
     <map enum-item="XINPUT_GAMEPAD_DPAD_(.*)" name-tmp="D_PAD_$1"/>
 


### PR DESCRIPTION
Change GamepadButtonFlags mapping from type short to ushort to fix issue with Y flag being incorrectly mapped. Y flag is currently mapped to Y = short.MinValue. It should be mapped to Y = 32768. I think changing the type to ushort should correctly remap the enumeration.

Edit: Although I think this behaviour of the code generator may indicate a problem with how it handles the mapping of flags enumerations. It shouldn't try to wrap the enumeration - if that's what it's doing. But that is beyond my ability to investigate, so I can only suggest that as a possible problem.
  
Edit : Apologies for the mess here, the correct type should be int, not ushort, as ushort isn't a supported type in the SharpDX build software for the enumeration. I've submitted a fresh pull request. But not sure if I should close this PR first or what. GitHub seems to have appended my fresh PR to this one. I've checked the enumeration after building SharpDX, and it looks OK now with int as the type.