### PR TITLE
Added initial support for the DXGI debug layer, might need to revise …

### DIFF
--- a/Source/SharpDX.DXGI/Debug.cs
+++ b/Source/SharpDX.DXGI/Debug.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2010-2018 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace SharpDX.DXGI
+{
+    public partial class Debug 
+    {
+        /// <summary>
+        /// If the DXGI debug layer is installed (e.g. on developer machines), creates the DXGI Debug object.
+        /// Otherwise, returns null.
+        /// </summary>
+        /// <remarks>
+        /// Currently doesn't work for Windows Store (aka UWP) apps 
+        /// </remarks>
+        public static Debug TryCreate()
+        {
+            return DebugInterface.TryCreateComPtr<Debug>(out IntPtr comPtr) ? new Debug(comPtr) : null;
+        }
+    }
+}

--- a/Source/SharpDX.DXGI/Debug1.cs
+++ b/Source/SharpDX.DXGI/Debug1.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2010-2018 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace SharpDX.DXGI
+{
+    public partial class Debug1
+    {
+        /// <summary>
+        /// If the DXGI debug layer is installed (e.g. on developer machines), creates the DXGI Debug1 object.
+        /// Otherwise, returns null.
+        /// </summary>
+        /// <remarks>
+        /// Currently doesn't work for Windows Store (aka UWP) apps 
+        /// </remarks>
+        public new static Debug1 TryCreate()
+        {
+            return DebugInterface.TryCreateComPtr<Debug1>(out IntPtr comPtr) ? new Debug1(comPtr) : null;
+        }
+    }
+}

--- a/Source/SharpDX.DXGI/DebugId.cs
+++ b/Source/SharpDX.DXGI/DebugId.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2010-2018 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace SharpDX.DXGI
+{
+    public static class DebugId
+    {
+        public static readonly Guid All = new Guid("e48ae283-da80-490b-87e6-43e9a9cfda08");
+        public static readonly Guid App = new Guid("06cd6e01-4219-4ebd-8709-27ed23360c62");
+        public static readonly Guid Dx = new Guid("35cdd7fc-13b2-421d-a5d7-7e4451287d64");
+        public static readonly Guid Dxgi = new Guid("25cddaa4-b1c6-47e1-ac3e-98875b5a2e2a");
+    }
+}

--- a/Source/SharpDX.DXGI/DebugInterface.cs
+++ b/Source/SharpDX.DXGI/DebugInterface.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace SharpDX.DXGI
+{
+    internal static class DebugInterface
+    {
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        private delegate Result GetDebugInterface(ref Guid guid, out IntPtr result);
+
+        private static readonly GetDebugInterface getDebugInterface;
+
+        static DebugInterface()
+        {
+            // https://blogs.msdn.microsoft.com/chuckw/2015/07/27/dxgi-debug-device/
+#if DESKTOP_APP
+            IntPtr moduleHandle = Kernel32.LoadLibraryEx("dxgidebug.dll", IntPtr.Zero, Kernel32.LoadLibraryFlags.LoadLibrarySearchSystem32);
+            if (moduleHandle != IntPtr.Zero)
+            {
+                IntPtr procedureHandle = Kernel32.GetProcAddress(moduleHandle, "DXGIGetDebugInterface");
+                if (procedureHandle != IntPtr.Zero)
+                {
+                    getDebugInterface = (GetDebugInterface)Marshal.GetDelegateForFunctionPointer(procedureHandle, typeof(GetDebugInterface));
+                }
+            }
+#else
+            getDebugInterface = null;
+#endif
+        }
+
+        public static bool TryCreateComPtr<T>(out IntPtr comPtr) where T : class
+        {
+            comPtr = IntPtr.Zero;
+            if (getDebugInterface == null)
+                return false;
+
+            var guid = typeof(T).GetTypeInfo().GUID;
+            var result = getDebugInterface(ref guid, out comPtr);
+            if (result.Failure)
+                return false;
+
+            return comPtr != IntPtr.Zero;
+        }
+
+    }
+}

--- a/Source/SharpDX.DXGI/InfoQueue.cs
+++ b/Source/SharpDX.DXGI/InfoQueue.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2010-2018 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+
+namespace SharpDX.DXGI
+{
+    public partial class InfoQueue
+    {
+        /// <summary>
+        /// If the DXGI debug layer is installed (e.g. on developer machines), creates the DXGI InfoQueue object.
+        /// Otherwise, returns null.
+        /// </summary>
+        /// <remarks>
+        /// Currently doesn't work for Windows Store (aka UWP) apps 
+        /// </remarks>
+        public static InfoQueue TryCreate()
+        {
+            return DebugInterface.TryCreateComPtr<InfoQueue>(out IntPtr comPtr) ? new InfoQueue(comPtr) : null;
+        }
+    }
+}

--- a/Source/SharpDX.DXGI/Kernel32.cs
+++ b/Source/SharpDX.DXGI/Kernel32.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace SharpDX.DXGI {
+    internal static class Kernel32
+    {
+        [Flags]
+        public enum LoadLibraryFlags : uint
+        {
+            DontResolveDllReferences = 0x00000001,
+            LoadIgnoreCodeAuthzLevel = 0x00000010,
+            LoadLibraryAsDatafile = 0x00000002,
+            LoadLibraryAsDatafileExclusive = 0x00000040,
+            LoadLibraryAsImageResource = 0x00000020,
+            LoadLibrarySearchApplicationDir = 0x00000200,
+            LoadLibrarySearchDefaultDirs = 0x00001000,
+            LoadLibrarySearchDllLoadDir = 0x00000100,
+            LoadLibrarySearchSystem32 = 0x00000800,
+            LoadLibrarySearchUserDirs = 0x00000400,
+            LoadWithAlteredSearchPath = 0x00000008
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hReservedNull, LoadLibraryFlags dwFlags);
+
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr GetModuleHandle(string lpModuleName);
+
+        [DllImport("kernel32.dll")]
+        public static extern IntPtr GetProcAddress(IntPtr hModule, string procName);
+    }
+}

--- a/Source/SharpDX.DXGI/Mapping.xml
+++ b/Source/SharpDX.DXGI/Mapping.xml
@@ -29,6 +29,7 @@
   <!-- DXGI includes -->
   <include id="dxgi" file="dxgi.h" attach="true" />
   <include id="dxgiformat" file="dxgiformat.h" attach="true" />
+  <include id="dxgidebug" file="dxgidebug.h" attach="true" />
   <include id="winerror" file="winerror.h"/>
   <include id="dxgitype" file="dxgitype.h" attach="true"/>
   <include id="dxgicommon" file="dxgicommon.h" attach="true"/>
@@ -44,6 +45,7 @@
     <context>sharpdx-dxgi-ext</context>
     <context>dxgi</context>
     <context>dxgiformat</context>
+    <context>dxgidebug</context>
     <context>dxgitype</context>
     <context>dxgicommon</context>
     <context>dxgi1_2</context>
@@ -158,6 +160,11 @@
     
     <map struct="DXGI_ADAPTER_DESC" pack="4"/>
     <map struct="DXGI_ADAPTER_DESC1" pack="4"/>
+
+    <map struct="DXGI_INFO_QUEUE_FILTER" name="InfoQueueFilter" />
+    <map struct="DXGI_INFO_QUEUE_FILTER_DESC" name="InfoQueueFilterDescription" />
+
+    <map struct="DXGI_DEBUG_ID" name="DebugId" />
 
     <!--
     // *****************************************************************
@@ -283,7 +290,8 @@
 
     <!-- TODO: No documentation - don't know how to map it. -->
     <remove function="DXGIGetDebugInterface1" />
-
+    <remove function="DXGIGetDebugInterface" />
+    
     <context-clear/>
   </mapping>
 </config>


### PR DESCRIPTION
I noticed I didn't get memory leak information about DXGI objects when calling `ReportLiveDeviceObjects`. I added support for the DXGI debug layer for doing this.

It also seems that using the DXGI approach to report the live objects doesn't require a device at all, so only the real leaking objects are printed, not the device/context etc that you still needed for calling `ReportLiveDeviceObjects` in the existing approach.

Since I had no idea how to do this correctly, I suspect feedback since this is just the first draft that is functional, but might not meet your requirements.

Thanks,
Peter Verswyvelen
