### PR TITLE
TryAquireNextFrame-API for Desktop-Duplication-API.

### DIFF
--- a/Source/SharpDX.DXGI/Mapping.xml
+++ b/Source/SharpDX.DXGI/Mapping.xml
@@ -249,6 +249,8 @@
     <map param="IDXGIOutput4::CheckOverlayColorSpaceSupport::pFlags" return="true"/>
     <map param="IDXGIOutput3::CheckOverlaySupport::pFlags" return="true"/>
 
+    <map method="IDXGIOutputDuplication::AcquireNextFrame" hresult="true" check="false" visibility="public" name="TryAcquireNextFrame" />
+
     <map param="ISurfaceImageSourceNative::BeginDraw::surface" return="true"/>
 
     <map interface="IVirtualSurfaceUpdatesCallbackNative" visibility="internal" callback="true" callback-dual="true" />

--- a/Source/SharpDX.DXGI/OutputDuplication.cs
+++ b/Source/SharpDX.DXGI/OutputDuplication.cs
@@ -29,6 +29,26 @@ namespace SharpDX.DXGI
             MapDesktopSurface(out mappedRect);
             return new DataRectangle(mappedRect.PBits, mappedRect.Pitch);
         }
+
+        /// <summary>
+        /// <p>Indicates that the application is ready to process the next desktop image.</p>	
+        /// </summary>
+        /// <param name="timeoutInMilliseconds"><dd> <p>The time-out interval, in milliseconds. This interval specifies the amount of time that this method waits for a new frame before it returns to the caller.  This method returns if the interval elapses, and a new desktop image is not available.</p> <p>For more information about the time-out interval, see Remarks.</p> </dd></param>	
+        /// <param name="frameInfoRef"><dd> <p>A reference to a memory location that receives the <strong><see cref="SharpDX.DXGI.OutputDuplicateFrameInformation"/></strong> structure that describes timing and presentation statistics for a frame.</p> </dd></param>	
+        /// <param name="desktopResourceOut"><dd> <p>A reference to a variable that receives the <strong><see cref="SharpDX.DXGI.Resource"/></strong> interface of the surface that contains the desktop bitmap.</p> </dd></param>	
+        /// <remarks>
+        /// <p>When <strong>AcquireNextFrame</strong> returns successfully, the calling application can access the desktop image that <strong>AcquireNextFrame</strong> returns in the variable at <em>ppDesktopResource</em>.	
+        /// If the caller specifies a zero time-out interval in the <em>TimeoutInMilliseconds</em> parameter, <strong>AcquireNextFrame</strong> verifies whether there is a new desktop image available, returns immediately, and indicates its outcome with the return value.  If the caller specifies an <strong>INFINITE</strong> time-out interval in the <em>TimeoutInMilliseconds</em> parameter, the time-out interval never elapses.</p><strong>Note</strong>??You cannot cancel the wait that you specified in the <em>TimeoutInMilliseconds</em> parameter. Therefore, if you must periodically check for other conditions (for example, a terminate signal), you should specify a non-<strong>INFINITE</strong> time-out interval. After the time-out interval elapses, you can check for these other conditions and then call <strong>AcquireNextFrame</strong> again to wait for the next frame.?<p><strong>AcquireNextFrame</strong> acquires a new desktop frame when the operating system either updates the desktop bitmap image or changes the shape or position of a hardware reference.  The new frame that <strong>AcquireNextFrame</strong> acquires might have only the desktop image updated, only the reference shape or position updated, or both.</p>	
+        /// </remarks>
+        /// <include file='.\..\..\Documentation\CodeComments.xml' path="/comments/comment[@id='IDXGIOutputDuplication::AcquireNextFrame']/*"/>	
+        /// <msdn-id>hh404615</msdn-id>
+        /// <unmanaged>HRESULT IDXGIOutputDuplication::AcquireNextFrame([In] unsigned int TimeoutInMilliseconds,[Out] DXGI_OUTDUPL_FRAME_INFO* pFrameInfo,[Out] IDXGIResource** ppDesktopResource)</unmanaged>	
+        /// <unmanaged-short>IDXGIOutputDuplication::AcquireNextFrame</unmanaged-short>	
+        public void AcquireNextFrame(int timeoutInMilliseconds, out SharpDX.DXGI.OutputDuplicateFrameInformation frameInfoRef, out SharpDX.DXGI.Resource desktopResourceOut)
+        {
+            var result = this.TryAcquireNextFrame(timeoutInMilliseconds, out frameInfoRef, out desktopResourceOut);
+            result.CheckError();
+        }
 #endif
     }
 }


### PR DESCRIPTION
AquireNextFrame returning a non-Ok result is expected behaviour
when submitting a short timeout, and shouldn't result in a (slow)
exception.

Should help fixing #861, #839, and #515.