### PR TITLE
[MediaFoundation] SinkWriter.GetStatistics fix

### DIFF
--- a/Source/SharpDX.MediaFoundation/Mapping-core.xml
+++ b/Source/SharpDX.MediaFoundation/Mapping-core.xml
@@ -787,6 +787,9 @@
     <map interface="IMFAsyncCallbackLogging" name="IAsyncCallbackLogging" callback="true"/>
 
     <map param="IMFByteStream::*.*::pb" type="void" attribute="in"/>
+    
+    <map method="IMFSinkWriter::GetStatistics" name="GetStatistics_" check="false" visibility="internal"/>
+    <map param="IMFSinkWriter::GetStatistics::pStats"  type="void" attribute="in"/>
 
     <map param="IMFByteStream::Begin[RW].*::punkState" type="void"/>
 

--- a/Source/SharpDX.MediaFoundation/SinkWriter.cs
+++ b/Source/SharpDX.MediaFoundation/SinkWriter.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SharpDX.MediaFoundation
+{
+    public partial class SinkWriter
+    {
+        /// <summary>	
+        /// <p>Gets statistics about the performance of the sink writer.</p>	
+        /// </summary>	
+        /// <param name="dwStreamIndex"><dd> <p>The zero-based index of a stream to query, or <strong><see cref="SharpDX.MediaFoundation.SinkWriterIndex.AllStreams"/> </strong> to query the media sink itself.</p> </dd></param>	
+        /// <param name="statsRef"><dd> <p>A reference to an <strong><see cref="SharpDX.MediaFoundation.SinkWriterStatistics"/></strong> structure. Before calling the method, set the <strong>cb</strong> member to the size of the structure in bytes. The method fills the structure with statistics from the sink writer.</p> </dd></param>	
+        /// <returns><p>This method can return one of these values.</p><table> <tr><th>Return code</th><th>Description</th></tr> <tr><td> <dl> <dt><strong><see cref="SharpDX.Result.Ok"/></strong></dt> </dl> </td><td> <p>Success.</p> </td></tr> <tr><td> <dl> <dt><strong><see cref="SharpDX.MediaFoundation.ResultCode.InvalidStreamNumber"/></strong></dt> </dl> </td><td> <p>Invalid stream number.</p> </td></tr> </table><p>?</p></returns>	
+        /// <remarks>	
+        /// <p>This interface is available on Windows?Vista if Platform Update Supplement for Windows?Vista is installed.</p>	
+        /// </remarks>	
+        /// <include file='.\..\..\Documentation\CodeComments.xml' path="/comments/comment[@id='IMFSinkWriter::GetStatistics']/*"/>	
+        /// <msdn-id>dd374650</msdn-id>	
+        /// <unmanaged>HRESULT IMFSinkWriter::GetStatistics([In] unsigned int dwStreamIndex,[Out] MF_SINK_WRITER_STATISTICS* pStats)</unmanaged>	
+        /// <unmanaged-short>IMFSinkWriter::GetStatistics</unmanaged-short>	
+        public void GetStatistics(int dwStreamIndex, out SharpDX.MediaFoundation.SinkWriterStatistics statsRef)
+        {
+            unsafe
+            {
+                statsRef = new SharpDX.MediaFoundation.SinkWriterStatistics();
+                statsRef.Cb = sizeof(SharpDX.MediaFoundation.SinkWriterStatistics);
+                fixed (void* statsRefPtr = &statsRef)
+                {
+                    GetStatistics_(dwStreamIndex, new IntPtr(statsRefPtr));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
A fix for `SinkWriter.GetStatistics`. It's broken at the moment as the `cb` field of `SinkWriterStatistics` needs to be set to the size of the struct in bytes before passing it to the method. This is described in the documentation:

https://msdn.microsoft.com/en-us/library/windows/desktop/dd374650(v=vs.85).aspx

I'm not sure if my code represents best practice, so let me know if there's a better way to fix this than what I've done and I'll resubmit it.