### PR TITLE
Renamed DXGI.Debug to DXGI.DXGIDebug

### DIFF
--- a/Source/SharpDX.DXGI/DXGIDebug.cs
+++ b/Source/SharpDX.DXGI/DXGIDebug.cs
@@ -21,18 +21,18 @@ using System;
 
 namespace SharpDX.DXGI
 {
-    public partial class Debug1
+    public partial class DXGIDebug
     {
         /// <summary>
-        /// If the DXGI debug layer is installed (e.g. on developer machines), creates the DXGI Debug1 object.
+        /// If the DXGI debug layer is installed (e.g. on developer machines), creates the DXGI Debug object.
         /// Otherwise, returns null.
         /// </summary>
         /// <remarks>
         /// Currently doesn't work for Windows Store (aka UWP) apps 
         /// </remarks>
-        public new static Debug1 TryCreate()
+        public static DXGIDebug TryCreate()
         {
-            return DebugInterface.TryCreateComPtr<Debug1>(out IntPtr comPtr) ? new Debug1(comPtr) : null;
+            return DebugInterface.TryCreateComPtr<DXGIDebug>(out IntPtr comPtr) ? new DXGIDebug(comPtr) : null;
         }
     }
 }

--- a/Source/SharpDX.DXGI/DXGIDebug1.cs
+++ b/Source/SharpDX.DXGI/DXGIDebug1.cs
@@ -21,18 +21,18 @@ using System;
 
 namespace SharpDX.DXGI
 {
-    public partial class Debug 
+    public partial class DXGIDebug1
     {
         /// <summary>
-        /// If the DXGI debug layer is installed (e.g. on developer machines), creates the DXGI Debug object.
+        /// If the DXGI debug layer is installed (e.g. on developer machines), creates the DXGI Debug1 object.
         /// Otherwise, returns null.
         /// </summary>
         /// <remarks>
         /// Currently doesn't work for Windows Store (aka UWP) apps 
         /// </remarks>
-        public static Debug TryCreate()
+        public new static DXGIDebug1 TryCreate()
         {
-            return DebugInterface.TryCreateComPtr<Debug>(out IntPtr comPtr) ? new Debug(comPtr) : null;
+            return DebugInterface.TryCreateComPtr<DXGIDebug1>(out IntPtr comPtr) ? new DXGIDebug1(comPtr) : null;
         }
     }
 }

--- a/Source/SharpDX.DXGI/Mapping.xml
+++ b/Source/SharpDX.DXGI/Mapping.xml
@@ -174,6 +174,8 @@
     <map interface="IDXGI(.+)" name-tmp="$1" />
     <map interface="IDXGIObject" name="DXGIObject" />
     <map interface="IDXGIDeviceSubObject" name="DeviceChild" />
+    <map interface="IDXGIDebug" name="DXGIDebug" />
+    <map interface="IDXGIDebug1" name="DXGIDebug1" />
 
     <map method=".*::GetPrivateData" check="false"/>
 


### PR DESCRIPTION
This fixes #1020 

This should please users complaining about #972 
 
It **will** break the few existing lines of code that are already using the newly added `DXGI.Debug` stuff.

On the other hand, not merging this PR will break **all** existing code that both is `using System.Diagnostics.Debug` and `using SharpDX.DXGI` at the same time.
