### PR TITLE
Correctly implement ColorGlyphRunEnumerator's GetCurrentRun method

### DIFF
--- a/Source/SharpDX.Direct2D1/DirectWrite/ColorGlyphRunEnumerator.cs
+++ b/Source/SharpDX.Direct2D1/DirectWrite/ColorGlyphRunEnumerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,7 +11,7 @@ namespace SharpDX.DirectWrite
         {
             GetCurrentRun(out IntPtr ptr);
             var run = new ColorGlyphRun();
-            run.__MarshalFrom(ref *((ColorGlpyhRun.__Native*)ptr));
+            run.__MarshalFrom(ref *((ColorGlyphRun.__Native*)ptr));
             return run;
         }
     }

--- a/Source/SharpDX.Direct2D1/DirectWrite/ColorGlyphRunEnumerator.cs
+++ b/Source/SharpDX.Direct2D1/DirectWrite/ColorGlyphRunEnumerator.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SharpDX.DirectWrite
+{
+    public partial class ColorGlyphRunEnumerator
+    {
+        public unsafe ColorGlyphRun GetCurrent()
+        {
+            GetCurrentRun(out IntPtr ptr);
+            var run = new ColorGlyphRun();
+            run.__MarshalFrom(ref *((ColorGlpyhRun.__Native*)ptr));
+            return run;
+        }
+    }
+}

--- a/Source/SharpDX.Direct2D1/DirectWrite/Mapping.xml
+++ b/Source/SharpDX.Direct2D1/DirectWrite/Mapping.xml
@@ -223,6 +223,8 @@
     <map param="IDWriteRemoteFontFileStream::BeginDownload::asyncResult" return="true" />
     <map method="IDWriteAsyncResult::GetResult" check="false"/>
     
+    <map param="IDWriteColorGlyphRunEnumerator::GetCurrentRun::colorGlyphRun" type="void" override-native-type="true" visibility="internal" />
+    
     <!-- Factory 2 -->
     <map method="IDWriteFactory2::TranslateColorGlyphRun" hresult="true" check="false" visibility="public" name="TryTranslateColorGlyphRun" />
 


### PR DESCRIPTION
Correctly implement ColorGlyphRunEnumerator's GetCurrentRun method as a GetCurrent() method. Fixes #1012.