### PR TITLE
Fix #1039.

### DIFF
--- a/Source/SharpDX.MediaFoundation/MediaAttributes.cs
+++ b/Source/SharpDX.MediaFoundation/MediaAttributes.cs
@@ -275,9 +275,9 @@ namespace SharpDX.MediaFoundation
                 return;
             }
 
-            if (typeof(T) == typeof(ComObject) || typeof(T).GetTypeInfo().IsSubclassOf(typeof(ComObject)))
+            if (typeof(T) == typeof(ComObject) || typeof(T).GetTypeInfo().IsSubclassOf(typeof(IUnknown)))
             {
-                Set(guidKey, ((ComObject)(object)value));
+                Set(guidKey, ((IUnknown)(object)value));
                 return;
             }
 


### PR DESCRIPTION
After the change to make `IUnknown` map to `IUnknown` instead of `ComObject`, the Set call here recursively called `Set<ComObject>` instead of the non-generic `Set` method that takes `IUnknown`.