### PR TITLE
Fix SharpGenTools Regressions

### DIFF
--- a/Source/Directory.build.props
+++ b/Source/Directory.build.props
@@ -50,7 +50,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpGenTools.Sdk" Version="1.1.1-ci462" PrivateAssets="All" />
+    <PackageReference Include="SharpGenTools.Sdk" Version="1.1.1-ci464" PrivateAssets="All" />
     <PackageReference Include="SharpGen.Doc.Msdn.Tasks" Version="1.1.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All"/>
     <SharpGenGlobalNamespaceOverrides Include="InterfaceArray" Override="ComArray" />

--- a/Source/SharpDX.Direct2D1/WIC/ColorContextsHelper.cs
+++ b/Source/SharpDX.Direct2D1/WIC/ColorContextsHelper.cs
@@ -59,7 +59,7 @@ namespace SharpDX.WIC
             ColorContext[] colorContexts;
             Result result = TryGetColorContexts(getColorContexts, imagingFactory, out colorContexts);
 
-            if (ResultCode.Unsupportedoperation != result)
+            if (ResultCode.UnsupportedOperation != result)
                 result.CheckError();
 
             return colorContexts;

--- a/Source/SharpDX.Direct3D11/Mapping.xml
+++ b/Source/SharpDX.Direct3D11/Mapping.xml
@@ -73,9 +73,13 @@
     <const from-macro="D3D11_REQ_TEXTURECUBE_DIMENSION" class="SharpDX.Direct3D11.Resource" type="int" name="MaximumTextureCubeSize" />
 
     <create class="ResultCode" visibility="public static" />
+    <context>winerror</context>
     <const from-macro="D3D11_ERROR_(.*)" type="SharpDX.ResultDescriptor" cpp-type="int" name="$1" class="SharpDX.Direct3D11.ResultCode" visibility="public static readonly">new SharpDX.ResultDescriptor($1, "$3", "$0", "$2")</const>
     <const from-macro="D3DX11_ERR_(.*)" type="SharpDX.ResultDescriptor" cpp-type="int" name="$1" class="SharpDX.Direct3D11.ResultCode" visibility="public static readonly">new SharpDX.ResultDescriptor($1, "$3", "$0", "$2")</const>
-
+    <context-clear />
+    
+    <context id="d3d11-all"/>
+    
     <create class="CommonShaderStage" visibility="public abstract partial" />
     <const from-macro="D3D11_COMMONSHADER_(.*)" class="SharpDX.Direct3D11.CommonShaderStage" type="int" name="$1" />
     <const from-macro="D3D11_IA_(.*)" class="SharpDX.Direct3D11.InputAssemblerStage" type="int" name="$1" />

--- a/Source/SharpDX/Direct3D/Mapping.xml
+++ b/Source/SharpDX/Direct3D/Mapping.xml
@@ -65,7 +65,7 @@
     // *****************************************************************
     -->
     <map enum="D3D(.*)" name-tmp="$1" />
-    <map enum-item="D3D(.*)" name-tmp="$1" />
+    <map enum-item="D3D(?!_PF_)(.*)" name-tmp="$1" />
     <map enum-item="D3D_INTERPOLATION(.*)" name-tmp="$1" />
     <remove enum-item="D3D(\d+)_CBF_USERPACKED.*"/>
     <remove enum-item="D3D(\d+)_PRIMITIVE_TOPOLOGY_.*" />


### PR DESCRIPTION
This should fix all of the remaining regressions in the generated code from SharpGenTools.

Fixes #1048.