### PR TITLE
Fix type check in MediaAttributes to work correctly with an interface type.

### DIFF
--- a/Source/SharpDX.MediaFoundation/MediaAttributes.cs
+++ b/Source/SharpDX.MediaFoundation/MediaAttributes.cs
@@ -275,7 +275,7 @@ namespace SharpDX.MediaFoundation
                 return;
             }
 
-            if (typeof(T) == typeof(ComObject) || typeof(T).GetTypeInfo().IsSubclassOf(typeof(IUnknown)))
+            if (typeof(T) == typeof(ComObject) || typeof(IUnknown).GetTypeInfo().IsAssignableFrom(typeof(T).GetTypeInfo()))
             {
                 Set(guidKey, ((IUnknown)(object)value));
                 return;


### PR DESCRIPTION
Fix type check in MediaAttributes as mentioned in #1039.