### PR TITLE
Add missing D2D1 Result Codes.

### DIFF
--- a/Source/SharpDX.Direct2D1/Mapping-direct2d1.xml
+++ b/Source/SharpDX.Direct2D1/Mapping-direct2d1.xml
@@ -58,6 +58,9 @@
   <include file="d2d1_3.h" attach="true" />
   <include file="d2d1effects_2.h" attach="true" />
   <include file="d2d1svg.h" attach="true" />
+  <include file="winerror.h">
+    <attach>D2DERR_(.*)</attach>
+  </include>
 
   <naming />
   
@@ -75,6 +78,7 @@
     <context>d2d1effectauthor</context>
     <context>d2d1effectauthor_1</context>
     <context>d2d1svg</context>
+    <context>winerror</context>
     
     <const from-guid="CLSID_D2D1([A-Z].*)" class="SharpDX.Direct2D1.Effect" type="System.Guid" name="$1">new System.Guid("$1")</const>
     <const from-guid="CLSID_D2D12DAffineTransform" class="SharpDX.Direct2D1.Effect" type="System.Guid" name="AffineTransform2D">new System.Guid("$1")</const>


### PR DESCRIPTION
Some of the D2D1 result codes are still missing. This PR adds back the ones that are defined in `winerror.h`.