### PR TITLE
Remove Marshal.FreeHGlobal over ConePointer to avoid native exception

### DIFF
--- a/Source/SharpDX.XAudio2/X3DAudio/Emitter.cs
+++ b/Source/SharpDX.XAudio2/X3DAudio/Emitter.cs
@@ -58,8 +58,6 @@ namespace SharpDX.X3DAudio
             {
                 // FreeHGlobal is crashing? Does X3DAudio perform deallocation?
 
-                if (ConePointer != IntPtr.Zero)
-                    Marshal.FreeHGlobal(ConePointer);
                 if (ChannelAzimuthsPointer != IntPtr.Zero)
                     Marshal.FreeHGlobal(ChannelAzimuthsPointer);
                 if (VolumeCurvePointer != IntPtr.Zero)


### PR DESCRIPTION
When **X3dAudio.Calculate** method is invoked for an emitter with a non-null **Cone**, an exception is raised indicating an invalid memory access.

To solve this, I have removed the **Marshal.FreeHGlobal(ConePointer)** invocation from the **Emitter.__Native.__MarshalFree()** method. That causes the exception, seeing that this structure is always allocated in the stack and no memory is allocated using **Marshal.AllocHGlobal**.