### PR TITLE
XAudio improvements

### DIFF
--- a/Source/SharpDX.XAudio2/MasteringVoice.cs
+++ b/Source/SharpDX.XAudio2/MasteringVoice.cs
@@ -57,6 +57,10 @@ namespace SharpDX.XAudio2
         public MasteringVoice(XAudio2 device, int inputChannels, int inputSampleRate, string deviceId)
             : base(device)
         {
+            if (device.Version == XAudio2Version.Version27)
+            {
+                throw new InvalidOperationException("This method is only valid on XAudio 2.8 or XAudio 2.9 version");
+            }
 
             device.CreateMasteringVoice(this, inputChannels, inputSampleRate, 0, deviceId, null, AudioStreamCategory.GameEffects);
         }
@@ -72,6 +76,7 @@ namespace SharpDX.XAudio2
         public MasteringVoice(XAudio2 device, int inputChannels, int inputSampleRate, int deviceIndex)
             : base(device)
         {
+            device.CheckVersion27();
             device.CreateMasteringVoice27(this, inputChannels, inputSampleRate, 0, deviceIndex, null);
         }
 

--- a/Source/SharpDX.XAudio2/Voice.cs
+++ b/Source/SharpDX.XAudio2/Voice.cs
@@ -31,6 +31,22 @@ namespace SharpDX.XAudio2
         }
 
         /// <summary>	
+        /// <p>Gets or Sets the overall volume level for the voice.</p>	
+        /// </summary>	
+        public float Volume
+        {
+            get
+            {
+                GetVolume(out var value);
+                return value;
+            }
+            set
+            {
+                SetVolume(value);
+            }
+        }
+
+        /// <summary>	
         /// <p>Returns information about the creation flags, input channels, and sample rate of a voice.</p>	
         /// </summary>	
         /// <include file='Documentation\CodeComments.xml' path="/comments/comment[@id='IXAudio2Voice::GetVoiceDetails']/*"/>	

--- a/Source/SharpDX.XAudio2/XAudio2.cs
+++ b/Source/SharpDX.XAudio2/XAudio2.cs
@@ -105,7 +105,6 @@ namespace SharpDX.XAudio2
                         }
                         catch (DllNotFoundException) { }
                         break;
-#if WINDOWS_UWP
                     case XAudio2Version.Version29:
                         try
                         {
@@ -114,7 +113,6 @@ namespace SharpDX.XAudio2
                         }
                         catch (DllNotFoundException) { }
                         break;
-#endif
                 }
 
                 // Early exit if we found a requestedVersion

--- a/Source/SharpDX.XAudio2/XAudio2.cs
+++ b/Source/SharpDX.XAudio2/XAudio2.cs
@@ -164,7 +164,7 @@ namespace SharpDX.XAudio2
             SetDebugConfiguration__vtbl_index += 3;
         }
 
-        private void CheckVersion27()
+        internal void CheckVersion27()
         {
             if (Version != XAudio2Version.Version27)
             {

--- a/Source/SharpDX.XAudio2/XAudio2.cs
+++ b/Source/SharpDX.XAudio2/XAudio2.cs
@@ -17,7 +17,9 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
 using System;
+using System.Runtime.InteropServices;
 
 namespace SharpDX.XAudio2
 {
@@ -49,6 +51,23 @@ namespace SharpDX.XAudio2
         /// Called if a critical system error occurs that requires XAudio2 to be closed down and restarted.
         /// </summary>
         public event EventHandler<ErrorEventArgs> CriticalError;
+
+#if !WINDOWS_UWP
+        private const uint RPC_E_CHANGED_MODE = 0x80010106;
+        private const uint COINIT_MULTITHREADED = 0x0;
+        private const uint COINIT_APARTMENTTHREADED = 0x2;
+        
+        static XAudio2()
+        {
+            if (CoInitializeEx(IntPtr.Zero, COINIT_APARTMENTTHREADED) == RPC_E_CHANGED_MODE)
+            {
+                CoInitializeEx(IntPtr.Zero, COINIT_MULTITHREADED);
+            }
+        }
+
+        [DllImport("ole32.dll", SetLastError = true, CallingConvention = CallingConvention.StdCall)]
+        private static extern uint CoInitializeEx([In, Optional] IntPtr pvReserved, [In]uint dwCoInit);
+#endif
 
         /// <summary>
         /// Initializes a new instance of the <see cref="XAudio2"/> class.

--- a/Source/SharpDX.XAudio2/XAudio29Functions.cs
+++ b/Source/SharpDX.XAudio2/XAudio29Functions.cs
@@ -1,4 +1,3 @@
-#if WINDOWS_UWP
 using System;
 using System.Runtime.InteropServices;
 
@@ -116,4 +115,3 @@ namespace SharpDX.XAudio2
         private unsafe static extern int CreateAudioVolumeMeter_(void* arg0);
     }
 }
-#endif


### PR DESCRIPTION
- Try to create XAudio 2.9 even on Windows10 desktop.
- Map Volume property to Voice.
- Handle CoInitializeEx on Desktop platforms (dotnet/corert#6046).