### PR TITLE
target ns2.0 when ns1.x exists

### DIFF
--- a/Source/SharpDX.Animation/SharpDX.Animation.csproj
+++ b/Source/SharpDX.Animation/SharpDX.Animation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0</TargetFrameworks>
     <PackageId>SharpDX.Animation</PackageId>
     <Product>SharpDX.Animation</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.Animation.xml</DocumentationFile>

--- a/Source/SharpDX.D3DCompiler/SharpDX.D3DCompiler.csproj
+++ b/Source/SharpDX.D3DCompiler/SharpDX.D3DCompiler.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0;uap10.0</TargetFrameworks>
     <PackageId>SharpDX.D3DCompiler</PackageId>
     <Product>SharpDX.D3DCompiler</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.D3DCompiler.xml</DocumentationFile>

--- a/Source/SharpDX.DXGI/SharpDX.DXGI.csproj
+++ b/Source/SharpDX.DXGI/SharpDX.DXGI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0;uap10.0</TargetFrameworks>
     <PackageId>SharpDX.DXGI</PackageId>
     <Product>SharpDX.DXGI</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.DXGI.xml</DocumentationFile>

--- a/Source/SharpDX.Direct2D1/SharpDX.Direct2D1.csproj
+++ b/Source/SharpDX.Direct2D1/SharpDX.Direct2D1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0;uap10.0</TargetFrameworks>
     <PackageId>SharpDX.Direct2D1</PackageId>
     <Product>SharpDX.Direct2D1</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.Direct2D1.xml</DocumentationFile>

--- a/Source/SharpDX.Direct3D10/SharpDX.Direct3D10.csproj
+++ b/Source/SharpDX.Direct3D10/SharpDX.Direct3D10.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0;uap10.0</TargetFrameworks>
     <PackageId>SharpDX.Direct3D10</PackageId>
     <Product>SharpDX.Direct3D10</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.Direct3D10.xml</DocumentationFile>

--- a/Source/SharpDX.Direct3D11.Effects/SharpDX.Direct3D11.Effects.csproj
+++ b/Source/SharpDX.Direct3D11.Effects/SharpDX.Direct3D11.Effects.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0;uap10.0</TargetFrameworks>
     <PackageId>SharpDX.Direct3D11.Effects</PackageId>
     <Product>SharpDX.Direct3D11.Effects</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.Direct3D11.Effects.xml</DocumentationFile>

--- a/Source/SharpDX.Direct3D11/SharpDX.Direct3D11.csproj
+++ b/Source/SharpDX.Direct3D11/SharpDX.Direct3D11.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0;uap10.0</TargetFrameworks>
     <PackageId>SharpDX.Direct3D11</PackageId>
     <Product>SharpDX.Direct3D11</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.Direct3D11.xml</DocumentationFile>

--- a/Source/SharpDX.Direct3D12/SharpDX.Direct3D12.csproj
+++ b/Source/SharpDX.Direct3D12/SharpDX.Direct3D12.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0;uap10.0</TargetFrameworks>
     <PackageId>SharpDX.Direct3D12</PackageId>
     <Product>SharpDX.Direct3D12</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.Direct3D12.xml</DocumentationFile>

--- a/Source/SharpDX.Direct3D9/SharpDX.Direct3D9.csproj
+++ b/Source/SharpDX.Direct3D9/SharpDX.Direct3D9.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <PackageId>SharpDX.Direct3D9</PackageId>
     <Product>SharpDX.Direct3D9</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.Direct3D9.xml</DocumentationFile>

--- a/Source/SharpDX.DirectComposition/SharpDX.DirectComposition.csproj
+++ b/Source/SharpDX.DirectComposition/SharpDX.DirectComposition.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <PackageId>SharpDX.DirectComposition</PackageId>
     <Product>SharpDX.DirectComposition</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.DirectComposition.xml</DocumentationFile>

--- a/Source/SharpDX.DirectInput/SharpDX.DirectInput.csproj
+++ b/Source/SharpDX.DirectInput/SharpDX.DirectInput.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <PackageId>SharpDX.DirectInput</PackageId>
     <Product>SharpDX.DirectInput</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.DirectInput.xml</DocumentationFile>

--- a/Source/SharpDX.DirectManipulation/SharpDX.DirectManipulation.csproj
+++ b/Source/SharpDX.DirectManipulation/SharpDX.DirectManipulation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0</TargetFrameworks>
     <PackageId>SharpDX.DirectManipulation</PackageId>
     <Product>SharpDX.DirectManipulation</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.DirectManipulation.xml</DocumentationFile>

--- a/Source/SharpDX.DirectSound/SharpDX.DirectSound.csproj
+++ b/Source/SharpDX.DirectSound/SharpDX.DirectSound.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <PackageId>SharpDX.DirectSound</PackageId>
     <Product>SharpDX.DirectSound</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.DirectSound.xml</DocumentationFile>
@@ -15,7 +15,7 @@
     <DefineConstants>$(DefineConstants);DESKTOP_APP</DefineConstants>
     <SharpDXAppType>DESKTOP_APP</SharpDXAppType>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard'))">
     <DefineConstants>$(DefineConstants);REFERENCE</DefineConstants>
     <SharpDXAppType>REFERENCE</SharpDXAppType>
   </PropertyGroup>

--- a/Source/SharpDX.Mathematics/SharpDX.Mathematics.csproj
+++ b/Source/SharpDX.Mathematics/SharpDX.Mathematics.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0;uap10.0</TargetFrameworks>
     <PackageId>SharpDX.Mathematics</PackageId>
     <Product>SharpDX.Mathematics</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.Mathematics.xml</DocumentationFile>

--- a/Source/SharpDX.MediaFoundation/SharpDX.MediaFoundation.csproj
+++ b/Source/SharpDX.MediaFoundation/SharpDX.MediaFoundation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0;uap10.0</TargetFrameworks>
     <PackageId>SharpDX.MediaFoundation</PackageId>
     <Product>SharpDX.MediaFoundation</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.MediaFoundation.xml</DocumentationFile>

--- a/Source/SharpDX.RawInput/SharpDX.RawInput.csproj
+++ b/Source/SharpDX.RawInput/SharpDX.RawInput.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard2.0</TargetFrameworks>
     <PackageId>SharpDX.RawInput</PackageId>
     <Product>SharpDX.RawInput</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.RawInput.xml</DocumentationFile>

--- a/Source/SharpDX.XAudio2/SharpDX.XAudio2.csproj
+++ b/Source/SharpDX.XAudio2/SharpDX.XAudio2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0;uap10.0</TargetFrameworks>
     <PackageId>SharpDX.XAudio2</PackageId>
     <Product>SharpDX.XAudio2</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.XAudio2.xml</DocumentationFile>

--- a/Source/SharpDX.XInput/SharpDX.XInput.csproj
+++ b/Source/SharpDX.XInput/SharpDX.XInput.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0;uap10.0</TargetFrameworks>
     <PackageId>SharpDX.XInput</PackageId>
     <Product>SharpDX.XInput</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.XInput.xml</DocumentationFile>

--- a/Source/SharpDX/SharpDX.csproj
+++ b/Source/SharpDX/SharpDX.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard1.1;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard1.1;netstandard2.0;uap10.0</TargetFrameworks>
     <PackageId>SharpDX</PackageId>
     <Product>SharpDX</Product>
     <DocumentationFile Condition="'$(Configuration)' == 'Release'">bin\$(Configuration)\$(TargetFramework)\SharpDX.xml</DocumentationFile>


### PR DESCRIPTION
The new Microsoft [OSS library guidance](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/) recommends that when targeting .NET Standard 1.x, also add a .NET Standard 2.0 target.

>✔️ DO include a netstandard2.0 target if you require a netstandard1.x target.
> All platforms supporting .NET Standard 2.0 will use the netstandard2.0 target and benefit from having a smaller package graph while older platforms will still work and fall back to using the netstandard1.x target.

