### PR TITLE
Direct3d11 small fix and improvement

### DIFF
--- a/Source/SharpDX.Direct3D11/DeviceContext.ComputeShaderStage.cs
+++ b/Source/SharpDX.Direct3D11/DeviceContext.ComputeShaderStage.cs
@@ -105,5 +105,16 @@ namespace SharpDX.Direct3D11
             fixed (void* puav = uavInitialCounts)
                 SetUnorderedAccessViews(startSlot, unorderedAccessViews != null ? unorderedAccessViews.Length : 0, (IntPtr)unorderedAccessViewsOut_, (IntPtr)puav);
         }
+
+        /// <summary>	
+        /// Sets an array of views for an unordered resource.	
+        /// </summary>	
+        /// <param name="startSlot">Index of the first element in the zero-based array to begin setting. </param>
+        /// <param name="unorderedAccessViews">A reference to an array of <see cref="SharpDX.Direct3D11.UnorderedAccessView"/> references to be set by the method. </param>
+        public unsafe void SetUnorderedAccessViews(int startSlot, ComArray<SharpDX.Direct3D11.UnorderedAccessView> unorderedAccessViews, int[] uavInitialCounts)
+        {
+            fixed (void* puav = uavInitialCounts)
+                SetUnorderedAccessViews(startSlot, unorderedAccessViews == null ? 0 : unorderedAccessViews.Length, unorderedAccessViews.NativePointer, (IntPtr)puav);
+        }
     }
 }

--- a/Source/SharpDX.Direct3D11/DeviceContext.OutputMergerStage.cs
+++ b/Source/SharpDX.Direct3D11/DeviceContext.OutputMergerStage.cs
@@ -122,7 +122,8 @@ namespace SharpDX.Direct3D11
             var temp = new UnorderedAccessView[count];
             DepthStencilView depthStencilView;
             GetRenderTargetsAndUnorderedAccessViews(0, new RenderTargetView[0], out depthStencilView, startSlot, count, temp);
-            depthStencilView.Dispose();
+            if (depthStencilView != null)
+                depthStencilView.Dispose();
             return temp;
         }
 


### PR DESCRIPTION
Hello, just a small change in Direct3D11.

* Fix GetUnorderedAccess view call in case no depth buffer is bound
* Add ComArray binding for CSSetUnorderedAccessViews (same as Constant buffer/SRV counterpart)

Thanks